### PR TITLE
Feat/add replacement

### DIFF
--- a/R/mod_inventory.R
+++ b/R/mod_inventory.R
@@ -466,15 +466,24 @@ mod_inventory_server <- function(id, user_coc) {
     })
     
     observeEvent(input$view_giw_btn, {
+      data <- giw_data() %>%
+        fselect(-date_created, -date_updated, -created_by, -updated_by)
+      
+      names(data) <- giw_variable_labels[match(names(data), names(giw_variable_labels))]
+      
       showModal(
         modalDialog(
           title = "GIW",
+          p(em("Locate the desired project(s) and copy the grant number into the Inventory")),
           DT::renderDT(
-            giw_data(),
+            data,
             fillContainer = TRUE,
             options = list(
               pageLength = 200,
-              scrollY = "400px"
+              scrollY = "400px",
+              columnDefs = list(
+                list(visible = FALSE, targets = 0)  # 0 = first column (0-based index)
+              )
             )
           ),
           size="xl",

--- a/R/utils/data_manipulations.R
+++ b/R/utils/data_manipulations.R
@@ -125,3 +125,22 @@ project_variable_labels <- c(
   "created_by" = "Created By",
   "date_created" = "Date Created"
 )
+
+giw_variable_labels <- c(
+  "grant_number" = "Grant Number",
+  "coc" = "CoC",
+  "applicant_name" = "Applicant Name",
+  "project_name" = "Project Name",
+  "expiration_year" = "Expiration Year",
+  "project_component" = "Project Component",
+  "restriction_dv_or_ydhp" = "Restriction: DV or YHDP",
+  "dv_ard_estimated" = "DV ARD Estimated",
+  "yhdp_ard_estimated" = "YHDP ARD Estimated",
+  "cocs_ard_estimated" = "CoCs ARD Estimated",
+  "total_units" = "Total Units",
+  "total_ara" = "Total ARA",
+  "date_created" = "Date Created",
+  "created_by" = "Created By",
+  "date_updated" = "Date Updated",
+  "updated_by" = "Updated By"
+)

--- a/global.R
+++ b/global.R
@@ -26,4 +26,5 @@ set.seed(123)
 files <- list.files(here("R/utils"), pattern = "\\.R$", full.names = TRUE)
 lapply(files, source)
 
+source(here("R/global_data_prep.R"))
 USER_ENTRY_BG_COLOR <- "#e6ffe6"


### PR DESCRIPTION
- smoothing out/making more robust the PostgresSQL to SQLite db conversion
- allow Reallocation and Replacement (pop-up form with shinyvalidate rules)
- additional helper functions
- allow saving and pulling to/from the database
- store user in server-level reactiveVal, along with coc and coc_instance_id