### PR TITLE
Feat/direct request

### DIFF
--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -416,8 +416,8 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
         coc_version_id = version_id,
         request_status = request_status_num,
         reason_for_rejection = NA,
-        date_created = Sys.time(),
-        date_updated = Sys.time()
+        date_created = format(Sys.time(), "%Y-%m-%d %H:%M:%S"),
+        date_updated = format(Sys.time(), "%Y-%m-%d %H:%M:%S")
       ) |>
         add_user_stamp(user_coc, is_new = TRUE)
       

--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -372,7 +372,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
         DT::DTOutput(ns("direct_request_coc_versions")),
         footer = tagList(
           # If they continue: go to next step
-          actionButton(ns('send_direct_request'), label='Send Request', disabled = TRUE),
+          actionButton(ns('send_direct_request'), label='Send Request', disabled = FALSE),
           # If they cancel: close pop-up
           modalButton(label='Cancel')
         )
@@ -405,9 +405,42 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
       )
     })
     
+    create_request <- function(cur_coc, version_name,
+                               requester) {
+      request_status_num <- get_lookup_refid('Sent','request_status')
+
+      version_id <- COC_VERSION_USERS |> 
+        fsubset(coc == cur_coc & coc_version_name == version_name) |> 
+        fselect('coc_version_id') %>% 
+        ffirst()
+      
+      request_row <- data.table(
+        coc_request_id = 1 + (get_db_tbl('coc_version_requests') |> fnrow()),
+        coc_version_id = version_id,
+        request_status = request_status_num,
+        reason_for_rejection = NA,
+        date_created = Sys.time(),
+        date_updated = Sys.time(),
+        created_by = requester,
+        updated_by = requester
+      )
+      
+        # Add row to requests table
+      DBI::dbAppendTable(
+        DB_CON,
+        "coc_version_requests",
+         request_row
+      )
+        
+    }
+    
     observeEvent(input$send_direct_request, {
       # TODO: Send email to version Owners of input$direct_request_coc_versions_rows_selected
-      
+      create_request(cur_coc = input$request_access_coc_dropdown,
+                     version_name = input$direct_request_coc_versions_cell_clicked$value,
+                     requester = user_coc$username)
+      removeModal()
+      showNotification('Request sent!', duration = 3)
     })
     
     # Requesting access to a CoC indirectly ---------------

--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -504,23 +504,32 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
     # is already created: 
     # send email to user associated with that other CoC Version
     observeEvent(input$send_indirect_request, {
-      req(!is.null(admin_email()))
+      #req(!is.null(admin_email()))
       
-      ## TODO: send email to admin of version that is requested
       
-      showModal(
-        modalDialog(
-          title = 'Request Sent',
-          helpText('Thank you. A request has been sent to the Admin for this version.'),
-          HTML(paste0('<p>Request Details</p>
-               <ul>
-               <li>Requested CoC: ', input$coc_dropdown,'</li>',
-                      '<li>Requested version: ',input$request_indirect_access_coc_dropdown,'</li>',    
-                      '<li>Requested at: ',Sys.time(),'</li>',
-                      '</ul>
-               '))
-        )
-      )
+      prev_requests <- get_db_tbl('coc_version_requests')
+      
+      version_id <- COC_VERSION_USERS |> 
+        fsubset(coc == input$request_indirect_access_coc_dropdown & 
+                  coc_version_name == input$indirect_request_coc_versions_cell_clicked$value) |> 
+        fselect('coc_version_id') %>% 
+        ffirst()
+      
+      check_if_already_requested <- prev_requests %>% 
+        fsubset(coc_version_id == version_id & 
+                  created_by == user_coc$username)
+      
+      if(fnrow(check_if_already_requested) > 0){
+        showNotification('You already have an outstanding request for this CoC Version. Please select another one.')
+      } else {
+        ## TODO: send email to admin of version that is requested
+        
+        create_request(cur_coc = input$request_indirect_access_coc_dropdown,
+                       version_id = version_id)
+        removeModal()
+        showNotification('Request sent!', duration = 3)
+      }
+      
     })
     
     observeEvent(input$new_hic_version, {

--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -447,15 +447,10 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
     # This is for when the user tried to create a new version 
     # but may not have known about an existing version for the same CoC
     request_access_indirect_coc_versions <- reactive({
-      req(input$request_indirect_access_coc_dropdown)
       
       COC_VERSION_USERS |>
-        fsubset(
-          username != user_coc$username & 
-            coc == input$request_indirect_access_coc_dropdown &
-            coc_version_role == owner_role_refid,
-          coc, coc_version_name, username
-        )
+        fsubset(username != user_coc$username) |>
+        fselect(coc, coc_version_name, username)
     })
     
     # When user clicks the "Request Access" button within the "Create Version" flow
@@ -488,8 +483,15 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
     
     output$indirect_request_coc_versions <- renderDT({
       req(input$request_indirect_access_coc_dropdown)
+      
+      versions_to_show <- request_access_indirect_coc_versions() |>
+        fsubset(coc == input$request_indirect_access_coc_dropdown & 
+                  username != user_coc$username)
+      
+      req(nrow(versions_to_show) > 0)
+      
       datatable(
-        request_access_indirect_coc_versions(),
+        versions_to_show,
         colnames = c("CoC", "Version Name", "Owner"),
         rownames = FALSE,
         options = list(dom = 'tip'),

--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -403,16 +403,11 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
       )
     })
     
-    create_request <- function(cur_coc, version_name) {
+    create_request <- function(cur_coc, version_id) {
       request_status_num <- get_lookup_refid('Sent','request_status')
-
-      version_id <- COC_VERSION_USERS |> 
-        fsubset(coc == cur_coc & coc_version_name == version_name) |> 
-        fselect('coc_version_id') %>% 
-        ffirst()
       
       request_row <- data.table(
-        coc_request_id = 1 + (get_db_tbl('coc_version_requests') |> fnrow()),
+        #coc_request_id = 1 + (get_db_tbl('coc_version_requests') |> fnrow()),
         coc_version_id = version_id,
         request_status = request_status_num,
         reason_for_rejection = NA,
@@ -421,7 +416,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
       ) |>
         add_user_stamp(user_coc, is_new = TRUE)
       
-        # Add row to requests table
+      # Add row to requests table
       DBI::dbAppendTable(
         DB_CON,
         "coc_version_requests",
@@ -431,12 +426,29 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
     }
     
     observeEvent(input$send_direct_request, {
-      # TODO: Send email to version Owners of input$direct_request_coc_versions_rows_selected
-      create_request(cur_coc = input$request_access_coc_dropdown,
-                     version_name = input$direct_request_coc_versions_cell_clicked$value,
-                     requester = user_coc$username)
-      removeModal()
-      showNotification('Request sent!', duration = 3)
+      
+      prev_requests <- get_db_tbl('coc_version_requests')
+      
+      version_id <- COC_VERSION_USERS |> 
+        fsubset(coc == input$request_access_coc_dropdown & 
+                coc_version_name == input$direct_request_coc_versions_cell_clicked$value) |> 
+        fselect('coc_version_id') %>% 
+        ffirst()
+      
+      check_if_already_requested <- prev_requests %>% 
+        fsubset(coc_version_id == version_id & 
+                  created_by == user_coc$username)
+      
+      if(fnrow(check_if_already_requested) > 0){
+        showNotification('You already have an outstanding request for this CoC Version. Please select another one.')
+      } else {
+        # TODO: Send email to version Owners of input$direct_request_coc_versions_rows_selected
+        create_request(cur_coc = input$request_access_coc_dropdown,
+                       version_id = version_id)
+        removeModal()
+        showNotification('Request sent!', duration = 3)
+      }
+     
     })
     
     # Requesting access to a CoC indirectly ---------------

--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -376,14 +376,6 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
       ))
     })
 
-    observeEvent(
-      input$direct_request_coc_versions_rows_selected,
-      updateActionButton(
-        ns('send_direct_request'), 
-        disabled = length(input$direct_request_coc_versions_rows_selected) > 0,
-        session = session
-      )             
-    )
     output$direct_request_coc_versions <- renderDT({
       req(input$request_access_coc_dropdown)
       
@@ -473,24 +465,27 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
       showModal(modalDialog(
         title = 'Request Access to a CoC',
         helpText('Select a CoC to view its versions...'),
+        selectInput(ns('request_indirect_access_coc_dropdown'),
+                    label = "Please choose a CoC:",
+                    choices = sort(funique(request_access_indirect_coc_versions()$coc))
+        ),
         DT::DTOutput(ns("indirect_request_coc_versions")),
         footer = tagList(
           # If they continue: go to next step
-          actionButton(ns('send_indirect_request'), label='Send Request', disabled = TRUE),
+          actionButton(ns('send_indirect_request'), label='Send Request', disabled = FALSE),
           # If they cancel: close pop-up
           modalButton(label='Cancel')
         )
       ))
     })
     
-    observeEvent(
-      input$indirect_request_coc_versions_rows_selected,
-      updateActionButton(
-        ns('send_indirect_request'), 
-        disabled = length(input$indirect_request_coc_versions_rows_selected) > 0,
-        session = session
-      )             
-    )
+    ## enable/disable request actionbuttons based on if a CoC version is selected from the modal table
+    observe({
+      shinyjs::toggleState(id = 'send_direct_request', condition = length(input$direct_request_coc_versions_rows_selected) > 0)
+      
+      shinyjs::toggleState(id = 'send_indirect_request', condition = length(input$indirect_request_coc_versions_rows_selected) > 0)
+    })
+    
     output$indirect_request_coc_versions <- renderDT({
       req(input$request_indirect_access_coc_dropdown)
       datatable(

--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -405,8 +405,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
       )
     })
     
-    create_request <- function(cur_coc, version_name,
-                               requester) {
+    create_request <- function(cur_coc, version_name) {
       request_status_num <- get_lookup_refid('Sent','request_status')
 
       version_id <- COC_VERSION_USERS |> 
@@ -420,10 +419,9 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
         request_status = request_status_num,
         reason_for_rejection = NA,
         date_created = Sys.time(),
-        date_updated = Sys.time(),
-        created_by = requester,
-        updated_by = requester
-      )
+        date_updated = Sys.time()
+      ) |>
+        add_user_stamp(user_coc, is_new = TRUE)
       
         # Add row to requests table
       DBI::dbAppendTable(

--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -132,7 +132,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
           title = 'Confirm Deletion',
           helpText("Are you sure you want to delete this CoC version? This action cannot be undone."),
           footer = tagList(
-            actionButton(ns('confirm_deletion'), label='Confirm'),
+            actionButton(ns('confirm_deletion'), label='Confirm', icon = icon('trash'), class='btn-danger'),
             modalButton(label='Cancel')
           )
         )
@@ -153,7 +153,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
             choices = sort(cocs$coc_code)
           ),
           footer = tagList(
-            actionButton(ns('choose_coc'), label="Next"),
+            actionButton(ns('choose_coc'), label="Continue", class='btn-primary'),
             modalButton(label="Cancel")
           ),
           easyClose = TRUE
@@ -175,7 +175,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
             value = paste0(current_version_name, "_v2")
           ),
           footer = tagList(
-            actionButton(ns('copy_orr_confirm'), label="Confirm"),
+            actionButton(ns('copy_orr_confirm'), label="Confirm", class="btn-primary"),
             modalButton(label="Cancel")
           ),
           easyClose = TRUE
@@ -276,7 +276,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
                           you can do so within the existing ORR and click "Cancel". If you still wish to create a new version, please click "Continue."')),
           footer = tagList(
             # If they continue: go to next step
-            actionButton(ns('continue_new_version'), label='Continue'),
+            actionButton(ns('continue_new_version'), label='Continue', class="btn-primary"),
             # If they cancel: close pop-up
             modalButton(label='Cancel')
           )
@@ -292,9 +292,10 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
           helpText(paste0('Another user (', check_if_others_have$username ,') has an existing version for CoC: ', coc_requested(),'. Would you like to request
                           access from this user, or continue creating a new version for this CoC?')),
           footer = tagList(
-            actionButton(ns('request_access_indirect'), label='Request Access'),
+            actionButton(ns('request_access_indirect'), label='Request Access', icon = icon('unlock'), class="btn-warning"),
             # If they continue: go to next step
-            actionButton(ns('continue_new_version2'), label='Create ORR anyway')
+            actionButton(ns('continue_new_version2'), label='Create New Version', icon('circle-plus'), class="btn-primary"),
+            modalButton('Cancel')
           )
         ))
        
@@ -307,7 +308,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
           helpText(paste0('You will become the Version Owner for this version of the ', coc_requested(), ' ORR, with the sole ability to manage other user requests to collaborate on this version. Would you like to continue?')),
           footer = tagList(
             # If they continue: go to next step
-            actionButton(ns('continue_new_version3'), label='Continue'),
+            actionButton(ns('continue_new_version3'), label='Continue', class="btn-primary"),
             # If they cancel: close pop-up
             modalButton(label='Cancel')
           )
@@ -319,6 +320,9 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
     observeEvent(
       c(input$continue_new_version, input$continue_new_version2, input$continue_new_version3),
       {
+        req(isTruthy(input$continue_new_version) || isTruthy(input$continue_new_version2) ||
+            isTruthy(input$continue_new_version3))
+       
         removeModal()
         choiceList <- setNames(
           c("import", "upload"), 
@@ -338,7 +342,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
             ),
             uiOutput(ns('hic_cond_select')),
             footer = tagList(
-              actionButton(inputId=ns('new_hic_version'),label='Next'),
+              actionButton(inputId=ns('new_hic_version'),label='Continue', class="btn-primary"),
               modalButton(label='Cancel')
             )
           ),
@@ -369,7 +373,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
         DT::DTOutput(ns("direct_request_coc_versions")),
         footer = tagList(
           # If they continue: go to next step
-          actionButton(ns('send_direct_request'), label='Send Request', disabled = FALSE),
+          actionButton(ns('send_direct_request'), label='Send Request', disabled = FALSE, class="btn-warning"),
           # If they cancel: close pop-up
           modalButton(label='Cancel')
         )
@@ -476,7 +480,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
         DT::DTOutput(ns("indirect_request_coc_versions")),
         footer = tagList(
           # If they continue: go to next step
-          actionButton(ns('send_indirect_request'), label='Send Request', disabled = TRUE),
+          actionButton(ns('send_indirect_request'), label='Send Request', disabled = TRUE, class="btn-warning"),
           # If they cancel: close pop-up
           modalButton(label='Cancel')
         )
@@ -540,7 +544,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
             value = initial_version_name,
           ),
           footer = tagList(
-            actionButton(ns('create_orr_confirm'), label="Create New Version"),
+            actionButton(ns('create_orr_confirm'), label="Create New Version", icon('circle-plus'), class="btn-primary"),
             modalButton(label="Cancel")
           ),
           easyClose = TRUE

--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -353,10 +353,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
     # allow user to view versions and request access
     request_access_direct_coc_versions <- reactive({
       COC_VERSION_USERS |>
-        fgroup_by(coc_version_id) |>
-        fmutate(user_associated_w_version = any(username == user_coc$username, na.rm=TRUE)) |>
-        fungroup() |>
-        fsubset(!user_associated_w_version) |>
+        fsubset(username != user_coc$username) |>
         fselect(coc, coc_version_name, username)
     })
     # When user clicks the "Request Access to a CoC" button
@@ -391,7 +388,8 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
       req(input$request_access_coc_dropdown)
       
       versions_to_show <- request_access_direct_coc_versions() |>
-        fsubset(coc == input$request_access_coc_dropdown)
+        fsubset(coc == input$request_access_coc_dropdown & 
+                username != user_coc$username)
       
       req(nrow(versions_to_show) > 0)
       

--- a/R/01b_mod_requests.R
+++ b/R/01b_mod_requests.R
@@ -135,8 +135,14 @@ mod_requests_server <- function(id, user_coc) {
           )
       )
     }
-    observeEvent(input$approve_request, {update_request("Approved")})
-    observeEvent(input$reject_request, {update_request("Rejected")})
+    observeEvent(input$approve_request, {
+      update_request("Approved")
+      showNotification('Request approved.', type='message') 
+    })
+    observeEvent(input$reject_request, {
+      update_request("Rejected")
+      showNotification('Request rejected.', type = 'warning')
+    })
     
     filter_requests <- function(status) {
       cur_requests(

--- a/R/01b_mod_requests.R
+++ b/R/01b_mod_requests.R
@@ -203,7 +203,9 @@ mod_requests_server <- function(id, user_coc) {
     }
     
     observeEvent(input$request_filters, {
-      filter_requests(status = input$request_filters)
+      status <- ifelse(input$request_filters == 'Outstanding', 'Sent',
+                       input$request_filters)
+      filter_requests(status = status)
     })
   
   }

--- a/R/01b_mod_requests.R
+++ b/R/01b_mod_requests.R
@@ -98,16 +98,18 @@ mod_requests_server <- function(id, user_coc) {
       selected_requests <- cur_requests()[input$requests_dt_rows_selected]
       
       apply(selected_requests, 1, function(row) {
-        # Set Status in Requests table
-        DBI::dbExecute(
-          DB_CON,
-          "UPDATE coc_version_requests 
+        
+       
+        if(request_status_num == 2){
+          
+          # Set Status in Requests table
+          DBI::dbExecute(
+            DB_CON,
+            "UPDATE coc_version_requests 
           SET request_status = $1, date_updated = CURRENT_TIMESTAMP, updated_by = $2
           WHERE coc_request_id = $3", 
-          params = list(request_status_num, user_coc$username, row[["coc_request_id"]])
-        )
-        
-        if(request_status_num == 2){
+            params = list(request_status_num, user_coc$username, row[["coc_request_id"]])
+          )
           
           # Create version user
           user_role_num <- get_lookup_refid("Editor", "coc_version_role")
@@ -123,6 +125,16 @@ mod_requests_server <- function(id, user_coc) {
               date_updated = format(Sys.time(), "%Y-%m-%d %H:%M:%S"),
               updated_by = user_coc$username
             )
+          )
+        } else if(request_status_num == 3){
+          # Set Status in Requests table
+          DBI::dbExecute(
+            DB_CON,
+            "UPDATE coc_version_requests 
+          SET request_status = $1, date_updated = CURRENT_TIMESTAMP, updated_by = $2,
+              reason_for_rejection = $3
+          WHERE coc_request_id = $4", 
+            params = list(request_status_num, user_coc$username, input$rej_reason, row[["coc_request_id"]])
           )
         }
       })
@@ -145,7 +157,7 @@ mod_requests_server <- function(id, user_coc) {
           title = 'Confirm Approval',
           "Please confirm that you would like to approve access to the selected CoC versions.",
           footer = tagList(
-            actionButton('confirm_approve', 'Confirm'),
+            actionButton(ns('confirm_approve'), 'Confirm'),
             modalButton('Cancel')
           )
         )
@@ -154,6 +166,7 @@ mod_requests_server <- function(id, user_coc) {
     
     observeEvent(input$confirm_approve, {
       update_request("Approved")
+      removeModal()
       showNotification('Request approved.', type='message') 
     })
     
@@ -161,14 +174,14 @@ mod_requests_server <- function(id, user_coc) {
       showModal(
         modalDialog(
           title = 'Confirm Rejection',
-          radioButton('rej_reason', label = 'Please specify a reason for rejection and confirm.',
+          radioButtons(ns('rej_reason'), label = 'Please specify a reason for rejection and confirm.',
                       choices = get_db_tbl('request_rejection_reasons')$request_rejection_reason),
           # conditionalPanel(
           #   condition = 'input.rej_reason == "Other"',
           #   textInput('rej_other_specify', "Other - please specify:"),
           # ),
           footer = tagList(
-            actionButton('confirm_reject', 'Confirm'),
+            actionButton(ns('confirm_reject'), 'Confirm'),
             modalButton('Cancel')
           )
         )
@@ -178,7 +191,7 @@ mod_requests_server <- function(id, user_coc) {
     
     observeEvent(input$confirm_reject, {
       update_request("Rejected")
-      
+      removeModal()
       showNotification('Request rejected.', type = 'warning')
     })
     

--- a/R/01b_mod_requests.R
+++ b/R/01b_mod_requests.R
@@ -11,10 +11,11 @@ mod_requests_ui <- function(id) {
           helpText("Please select a row from the table below to update a request."),
           br(),
           br(),
-          actionGroupButtons(
-            c(ns("filter_sent"), ns("filter_approved"), ns("filter_rejected")),
-            c("Outstanding", "Approved", "Rejected"),
-            status = "default"
+          radioGroupButtons(
+            ns('request_filters'),
+            choices = c('Outstanding','Approved','Rejected'),
+            selected = NULL,
+            status = "primary"
           ),
           DTOutput(ns('requests_dt'))|> shinycssloaders::withSpinner(),
           actionButton(ns('approve_request'), label='Approve', class='btn-success'),
@@ -150,8 +151,10 @@ mod_requests_server <- function(id, user_coc) {
           fsubset(request_status == status)
       )
     }
-    observeEvent(input$filter_sent, {filter_requests("Sent")})
-    observeEvent(input$filter_approved, {filter_requests("Approved")})
-    observeEvent(input$filter_rejected, {filter_requests("Rejected")})
+    
+    observeEvent(input$request_filters, {
+      filter_requests(status = input$request_filters)
+    })
+  
   }
 )}

--- a/R/01b_mod_requests.R
+++ b/R/01b_mod_requests.R
@@ -107,21 +107,24 @@ mod_requests_server <- function(id, user_coc) {
           params = list(request_status_num, user_coc$username, row[["coc_request_id"]])
         )
         
-        # Create version user
-        user_role_num <- get_lookup_refid("Editor", "coc_version_role")
-        DBI::dbAppendTable(
-          DB_CON,
-          "coc_version_users",
-          data.table(
-            coc_version_id = row[["coc_version_id"]],
-            username = row[["created_by"]],
-            coc_version_role = user_role_num,  # Owner, Owner, Editor, Owner
-            created_by = user_coc$username,
-            date_created = format(Sys.time(), "%Y-%m-%d %H:%M:%S"),
-            date_updated = format(Sys.time(), "%Y-%m-%d %H:%M:%S"),
-            updated_by = user_coc$username
+        if(request_status_num == 2){
+          
+          # Create version user
+          user_role_num <- get_lookup_refid("Editor", "coc_version_role")
+          DBI::dbAppendTable(
+            DB_CON,
+            "coc_version_users",
+            data.table(
+              coc_version_id = row[["coc_version_id"]],
+              username = row[["created_by"]],
+              coc_version_role = user_role_num,  # Owner, Owner, Editor, Owner
+              created_by = user_coc$username,
+              date_created = format(Sys.time(), "%Y-%m-%d %H:%M:%S"),
+              date_updated = format(Sys.time(), "%Y-%m-%d %H:%M:%S"),
+              updated_by = user_coc$username
+            )
           )
-        )
+        }
       })
         
       # Updaet datatable proxy

--- a/R/01b_mod_requests.R
+++ b/R/01b_mod_requests.R
@@ -140,11 +140,45 @@ mod_requests_server <- function(id, user_coc) {
       )
     }
     observeEvent(input$approve_request, {
+      showModal(
+        modalDialog(
+          title = 'Confirm Approval',
+          "Please confirm that you would like to approve access to the selected CoC versions.",
+          footer = tagList(
+            actionButton('confirm_approve', 'Confirm'),
+            modalButton('Cancel')
+          )
+        )
+      )
+    })
+    
+    observeEvent(input$confirm_approve, {
       update_request("Approved")
       showNotification('Request approved.', type='message') 
     })
+    
     observeEvent(input$reject_request, {
+      showModal(
+        modalDialog(
+          title = 'Confirm Rejection',
+          radioButton('rej_reason', label = 'Please specify a reason for rejection and confirm.',
+                      choices = get_db_tbl('request_rejection_reasons')$request_rejection_reason),
+          # conditionalPanel(
+          #   condition = 'input.rej_reason == "Other"',
+          #   textInput('rej_other_specify', "Other - please specify:"),
+          # ),
+          footer = tagList(
+            actionButton('confirm_reject', 'Confirm'),
+            modalButton('Cancel')
+          )
+        )
+      )
+      
+    })
+    
+    observeEvent(input$confirm_reject, {
       update_request("Rejected")
+      
       showNotification('Request rejected.', type = 'warning')
     })
     

--- a/R/utils/get_db_data.R
+++ b/R/utils/get_db_data.R
@@ -42,8 +42,16 @@ get_db_query <- function(sql, params = NULL) {
 
 
 get_db_tbl <- function(tbl_name) {
-  dbReadTable(DB_CON, tbl_name) |>
+  tbl <- dbReadTable(DB_CON, tbl_name) |>
     qDT()
+  
+  if("date_created" %in% names(tbl)) 
+    tbl[, date_created := as.POSIXct(date_created)]
+  
+  if("date_updated" %in% names(tbl)) 
+    tbl[, date_updated := as.POSIXct(date_updated)]
+  
+  return(tbl)
 }
 
 DB_CON <- get_db_connection()

--- a/database/populate_db.R
+++ b/database/populate_db.R
@@ -5,7 +5,7 @@ source("R/utils/get_db_data.R")
 library(data.table)
 library(glue)
 
-HIC_DATA_FILEPATH <- here("database/HIC_RawData2025 - 7.21.25_TEST.csv")
+HIC_DATA_FILEPATH <- here("database/HIC_RawData2025-7.21.25_TEST.csv")
 GIW_DATA_FILEPATH <- here("database/GIW.csv")
 HUD_ARD_DATA_FILEPATH <- here("database/HUD_ard_report.csv")
 


### PR DESCRIPTION
Builds out creation of direct requests for access to CoC version
- checks if a request already exists for that CoC version
- if  not, creates and appends a row to the `coc_version_requests` table with status 'Sent'
- when approved, updates `coc_version_requests` to show approved
- when approved, the CoC version is then available in the top versions table
- this approval also shows in both the requester's and approvers 'Approved' table...... TBD on how to handle that