### PR TITLE
Dev

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -27,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
-          gemini_model: 'gemini-3-flash-preview'
+          gemini_model: 'gemini-flash-latest'
           pr_number: ${{ github.event.issue.number || github.event.pull_request.number }}
           prompt: |
             /gemini-review

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -25,10 +25,10 @@ jobs:
         env:
           # This is the key part: The CLI looks for this specific Env Var name
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           gemini_model: 'gemini-flash-latest'
-          pr_number: ${{ github.event.issue.number || github.event.pull_request.number }}
           prompt: |
             /gemini-review
             

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -13,11 +13,22 @@ permissions:
 
 jobs:
   review:
+    if: >
+        github.event_name == 'pull_request' || 
+        github.event_name == 'workflow_dispatch' || 
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/gemini-review'))
+      
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@v4'
         with:
+          # If it's a comment, get the PR branch. 
+          # If it's a direct PR trigger, get the PR SHA.
+          # Otherwise, use the default.
+          # This ensures that if it's a comment, it gets the PR code. 
+          # If it's a push, it gets the pushed code.
+          ref: ${{ github.event.pull_request.head.sha || github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number) || github.ref }}
           fetch-depth: 0 # Important for the CLI to see the git history
 
       - name: 'Gemini Review'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -39,7 +39,10 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
-          gemini_model: 'gemini-flash-latest'
+          # gemini_model: 'gemini-1.5-flash'
+          gemini_model: 'gemini-2.0-flash'
+          # gemini_model: 'gemini-flash-latest' # (uses 2.5 flash as of 2/16/26)
+          # gemini-model: 'gemini-3.0-flash-preview' # will try this when limits reset
           prompt: |
             /gemini-review
             


### PR DESCRIPTION
updating gemini workflow again. trying to:
1. use 2.0-flash, which has higher limits for the free tier
2. make sure gemini looks at the correct branch if triggered by a comment.