### PR TITLE
hotfix/timestamps

### DIFF
--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -255,11 +255,10 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
           new_version |>
             fmutate(
               coc_version_id = new_version_user$coc_version_id,
-              coc_version_role = new_version_user$coc_version_role,
               coc_status = get_lookup_label(coc_status, "coc_status"),
-              coc_version_role = get_lookup_label(coc_version_role, "coc_version_role"),
-              date_updated = as.POSIXct(new_coc_version_info[[1]]$date_updated),
-              date_created = as.POSIXct(new_coc_version_info[[1]]$date_updated)
+              coc_version_role = get_lookup_label(new_version_user$coc_version_role, "coc_version_role"),
+              date_updated = format_timestamp(new_coc_version_info$date_updated[1]),
+              date_created = format_timestamp(new_coc_version_info$date_updated[1])
             ),
           fill=TRUE
         ) %>% fselect(-created_by)

--- a/R/utils/data_manipulations.R
+++ b/R/utils/data_manipulations.R
@@ -205,12 +205,13 @@ insert_and_return <- function(table, new_dt, return_cols) {
   return(results)
 }
 
-format_timestamp_for_db <- function(t) {
-  format(lubridate::with_tz(t, "UTC"), "%Y-%m-%d %H:%M:%S")
+format_timestamp <- function(t) {
+  strftime(t, format = "%Y-%m-%d %H:%M:%S")
 }
 
+
 get_db_timestamp <- function() {
-  format_timestamp_for_db(Sys.time())
+  as.character(Sys.time())
 }
 
 save_to_db <- function(p, sql, params, tbl_name) {


### PR DESCRIPTION
don't really need to format_timestamp_for_db anymore. Timestamps are all automatic now. And if we do, it should be the raw character version, with the .milliseconds. In fact, the get_db_timestamp function used in generating test data should reflect this format.

instead, we could use a format_timestamp function to format for displaying in the app.