### PR TITLE
ignore ES projects

### DIFF
--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -653,7 +653,11 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
           coc_amount_awarded_last_year = as.numeric(NA),
           coc_amount_expended_last_year = as.numeric(NA),
           coc_funding_requested = as.numeric(NA),
-          funding_action = fifelse(mckinneyvento == "Yes", "Renew", "Ignore"),
+          funding_action = fifelse(
+            project_type == "ES" | mckinneyvento == "No",
+            "Ignore", 
+            "Renew"
+          ),
           coc_version_id = coc_version_id,
           # additional cols user will fill out
           is_dedicated_ch_fam = factor_yesno(NA),


### PR DESCRIPTION
ES projects don't get rated and are automatically moved to the Excluded ranking table. We don't want to not pull them though, so that users can fix anything, if needed. Instead, we mark them as "ignore"