### PR TITLE
priorities fixes

### DIFF
--- a/R/03_mod_funding_priorities.R
+++ b/R/03_mod_funding_priorities.R
@@ -331,11 +331,6 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
             )
           )
         ),
-        editable = list(
-          target = 'cell',
-          disable = list(columns = c(0))
-        ),
-        extension = 'KeyTable',
         options = list(
           dom = 't',
           searching = FALSE,

--- a/R/utils/inline_editable_datatable.R
+++ b/R/utils/inline_editable_datatable.R
@@ -165,6 +165,7 @@ initialize_inline_edit_table_ui <- function(
     fillContainer = TRUE,
     callback_js = "return table;",
     has_double_header = FALSE,
+    extensions = c("Buttons","KeyTable"),
     ...
 ) {
   # --- STEP 1: handle factors as dropdowns ---
@@ -204,7 +205,7 @@ initialize_inline_edit_table_ui <- function(
   dt <- datatable(
     data,
     style = "default",
-    extensions = c('Buttons', 'KeyTable'),
+    extensions = extensions,
     colnames = colnames,
     editable = list(
       target = "cell",


### PR DESCRIPTION
- removed duplicate `editable` call. Instead, just need the existing cols_to_disable parameter
- removing the extension call in the priorities table. it's already a default in the inline_Editable table