### PR TITLE
Check if pool is valid in user settings

### DIFF
--- a/R/02_mod_inventory.R
+++ b/R/02_mod_inventory.R
@@ -123,7 +123,7 @@ mod_inventory_server <- function(id, nav_control, user_coc, parent_session, modu
       initial_cols_to_hide <- setdiff(names(projects_data()), initial_cols_to_show )
       
       # retrieve user columns from user-settings table
-      user_previous_hidden <- get_project_fields_to_hide(user_coc$coc_version_id, user_coc$username)
+      user_previous_hidden <- get_project_fields_to_hide(get_db_pool(),user_coc$coc_version_id, user_coc$username)
       user_cols_to_hide <- gsub('disp_','',user_previous_hidden)
 
       if(length(user_cols_to_hide) > 0){

--- a/R/04_mod_rating.R
+++ b/R/04_mod_rating.R
@@ -116,7 +116,7 @@ mod_rating_server <- function(id, nav_control, user_coc, parent_session, module_
       req(user_coc$auth)
       req(!is.null(user_coc$coc_version_id) & nav_control() == 'rating')
       
-      user_previous_method <- get_user_setting('rating_method', user_coc$coc_version_id, user_coc$username)
+      user_previous_method <- get_user_setting(get_db_pool(), 'rating_method', user_coc$coc_version_id, user_coc$username)
       
       if(length(user_previous_method) > 0){
         shinyjs::click(id = glue::glue('select_{user_previous_method}'))
@@ -124,14 +124,14 @@ mod_rating_server <- function(id, nav_control, user_coc, parent_session, module_
       
         ## set up subtabs if using in-app rating method
         if(user_previous_method == 'in_app'){
-          user_previous_tab <- get_user_setting('rating_tab', user_coc$coc_version_id, user_coc$username)
+          user_previous_tab <- get_user_setting(get_db_pool(), 'rating_tab', user_coc$coc_version_id, user_coc$username)
           if(length(user_previous_tab) > 0){
             
             nav_select(id = 'rating_tabs', selected = glue::glue('rating-{user_previous_tab}'))
             
           }
           
-          user_previous_subtab <- get_user_setting('rating_subtab', user_coc$coc_version_id, user_coc$username)
+          user_previous_subtab <- get_user_setting(get_db_pool(), 'rating_subtab', user_coc$coc_version_id, user_coc$username)
           
           if(length(user_previous_subtab) > 0){
             if(length(user_previous_tab) == 0 || user_previous_tab == 'customize_criteria'){

--- a/R/04a_mod_in_app_rating.R
+++ b/R/04a_mod_in_app_rating.R
@@ -36,7 +36,7 @@ mod_in_app_rating_server <- function(id, user_coc, funding_action, nav_control, 
       req(!is.null(user_coc$coc_version_id) & nav_control() == 'rating')
       req(nrow(all_projects()) > 0)
       
-      user_prev_project_selected <- get_user_setting(glue::glue('rating_{id}_project_selected'), user_coc$coc_version_id, user_coc$username)
+      user_prev_project_selected <- get_user_setting(get_db_pool(), glue::glue('rating_{id}_project_selected'), user_coc$coc_version_id, user_coc$username)
       
       if(length(user_prev_project_selected) > 0){
         updateSelectInput(session, inputId = 'project_select', selected = user_prev_project_selected)

--- a/R/app_db_funcs/db_02_mod_inventory.R
+++ b/R/app_db_funcs/db_02_mod_inventory.R
@@ -8,6 +8,7 @@ get_project_fields_to_hide <- function(p, coc_version_id, username){
   } else {
     return(character(0))
   }
+}
 
 update_inventory_db <- function(new_value, col_name, proj_id) {
   db_execute(

--- a/R/app_db_funcs/db_02_mod_inventory.R
+++ b/R/app_db_funcs/db_02_mod_inventory.R
@@ -1,6 +1,12 @@
-get_project_fields_to_hide <- function(coc_version_id, username){
-  get_db_query(
-    "SELECT setting_name FROM user_settings WHERE coc_version_id = $1 AND coc_user = $2 AND setting_value = 'hide' AND setting_name LIKE 'disp_%'",
-    params = list(coc_version_id, username)
-  ) |> unlist(use.names = FALSE)
+get_project_fields_to_hide <- function(p, coc_version_id, username){
+  
+  if(p$valid){
+    get_db_query(
+      "SELECT setting_name FROM user_settings WHERE coc_version_id = $1 AND coc_user = $2 AND setting_value = 'hide' AND setting_name LIKE 'disp_%'",
+      params = list(coc_version_id, username)
+    ) |> unlist(use.names = FALSE)
+  } else {
+    return(character(0))
+  }
+ 
 }

--- a/R/utils/user_settings.R
+++ b/R/utils/user_settings.R
@@ -1,11 +1,17 @@
 ## retrieve individual user setting value from DB
-get_user_setting <- function(setting_nm, coc_version_id, username){
-  get_db_query(
-    "SELECT setting_value FROM user_settings WHERE coc_version_id = $1 AND coc_user = $2 AND setting_name = $3",
-    params = list(coc_version_id,
-                  username,
-                  setting_nm)
-  ) |> unlist(use.names = FALSE)
+get_user_setting <- function(p, setting_nm, coc_version_id, username){
+  
+  if(p$valid){
+    get_db_query(
+      "SELECT setting_value FROM user_settings WHERE coc_version_id = $1 AND coc_user = $2 AND setting_name = $3",
+      params = list(coc_version_id,
+                    username,
+                    setting_nm)
+    ) |> unlist(use.names = FALSE)
+  } else {
+    return(character(0))
+  }
+  
 }
 
 ## on app exit, update individual settings
@@ -50,7 +56,10 @@ update_all_user_settings <- function(user_coc, tab_name){
  
   p <- get_db_pool()
   
-  existing_settings <-  dbGetQuery(get_db_pool(),
+  if(!p$valid)
+    return(NULL)
+  
+  existing_settings <-  dbGetQuery(p,
                                    'SELECT * FROM user_settings WHERE coc_version_id = $1 AND coc_user = $2', 
                                    params = list(isolate(user_coc$coc_version_id),
                                                  isolate(user_coc$username)))
@@ -78,7 +87,7 @@ update_all_user_settings <- function(user_coc, tab_name){
   if(fnrow(disp_existing) > 0){
 
     current_selection <- isolate(user_coc$settings$cols_to_hide)
-    previous_selection <-  get_project_fields_to_hide(isolate(user_coc$coc_version_id),
+    previous_selection <-  get_project_fields_to_hide(get_db_pool(), isolate(user_coc$coc_version_id),
                                                  isolate(user_coc$username))
 
 


### PR DESCRIPTION
The user settings were erroring in the rating tab because the pool was closed. This returned `list(ok = FALSE, error = e$message)` which had length 2 and broke the if statement comparison.

Now checking `get_db_pool()$valid` before querying for user settings and returning a length-0 object if not valid.