### PR TITLE
version_id for optimistic locking

### DIFF
--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -60,7 +60,8 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
     ####
     output$coc_versions_dt <- renderDT({
       req(user_coc$auth)
-      datatable(users_versions(), 
+      
+      datatable(users_versions() |> fselect(-version_id), 
                 colnames = unname(versions_variable_labels[match(names(users_versions()),  names(versions_variable_labels))]),
                 rownames = FALSE,
                 options = list(

--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -61,8 +61,9 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
     output$coc_versions_dt <- renderDT({
       req(user_coc$auth)
       
-      datatable(users_versions() |> fselect(-version_id), 
-                colnames = unname(versions_variable_labels[match(names(users_versions()),  names(versions_variable_labels))]),
+      data <- users_versions() |> fselect(-version_id)
+      datatable(data, 
+                colnames = unname(versions_variable_labels[match(names(data),  names(versions_variable_labels))]),
                 rownames = FALSE,
                 options = list(
                   dom = 'ftip', 

--- a/R/01b_mod_requests.R
+++ b/R/01b_mod_requests.R
@@ -132,7 +132,7 @@ mod_requests_server <- function(id, user_coc, module_returns) {
           username,
           reason_for_rejection,
           coc_request_id,
-          date_updated
+          version_id
         )
       
       pool::poolWithTransaction(get_db_pool(), function(p) {

--- a/R/01b_mod_requests.R
+++ b/R/01b_mod_requests.R
@@ -73,12 +73,13 @@ mod_requests_server <- function(id, user_coc) {
     output$requests_dt <- renderDT({
       req(user_coc$auth)
       
+      data <- cur_requests_filtered() |> fselect(-version_id)
       # create "sent to " field when category is Sent
-      cols_to_hide <- which(names(cur_requests()) %in% c('coc_request_id', 'coc_version_id')) - 1
+      cols_to_hide <- which(names(data) %in% c('coc_request_id', 'coc_version_id')) - 1
       
       datatable(
-        cur_requests_filtered(),
-        colnames = unname(requests_variable_labels[names(cur_requests())]),
+        data,
+        colnames = unname(requests_variable_labels[names(data)]),
         escape=-1,
         style = 'default',
         options = list(

--- a/R/02_mod_inventory.R
+++ b/R/02_mod_inventory.R
@@ -264,11 +264,11 @@ mod_inventory_server <- function(id, nav_control, user_coc, parent_session) {
     ## datatable proxy-----
     # By updating a proxy (via `replaceData`), updates are faster and don't "flicker" the table
     # However it doesn't work when adding new rows
-    projects_table_proxy <- dataTableProxy(ns("projects_table"),session = session)
+    projects_table_proxy <- dataTableProxy("projects_table",session = session)
     
     observe({
       req(projects_data())
-      replaceData(projects_table_proxy, projects_data(), resetPaging = FALSE)
+      replaceData(projects_table_proxy, projects_data(), resetPaging = FALSE, rownames = FALSE)
     })
     
     # Checks whether value is valid

--- a/R/03_mod_funding_priorities.R
+++ b/R/03_mod_funding_priorities.R
@@ -423,7 +423,7 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
         ) |>
         join(
           coc_funding_priorities() |> 
-            fselect(project_type, target_population, population_group, date_updated),
+            fselect(project_type, target_population, population_group, version_id),
           on = c("project_type", "target_population", "population_group")
         )
       
@@ -442,7 +442,7 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
         changed_data$population_group,
         changed_data[[metric_name]],
         user_coc$username,
-        date_updated = changed_data$date_updated
+        version_id = changed_data$version_id
       )
       
       needs_refresh <- update_coc_funding_priorities_db(
@@ -469,7 +469,7 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
           created_by = params$created_by
         ) |>
         fsubset(selected_new != fcoalesce(as.logical(selected), FALSE)) |>
-        fselect(coc_version_id, coc_nofo_opportunity_id, selected_new, created_by, date_updated)
+        fselect(coc_version_id, coc_nofo_opportunity_id, selected_new, created_by, version_id)
     }
     
     ## Save to db -------------

--- a/R/04a1a_mod_customize_coc_thresholds.R
+++ b/R/04a1a_mod_customize_coc_thresholds.R
@@ -92,7 +92,7 @@ mod_customize_coc_thresholds_server <- function(id, user_coc, nav_control, modul
           coc_version_id = params$coc_version_id,
           username = params$username
         ) |>
-        fselect(threshold_id, coc_version_id, selected, username, selected_threshold_date_updated)
+        fselect(threshold_id, coc_version_id, selected, username, selected_threshold_version_id)
     }
     
     observeEvent(input$save_thresholds, {
@@ -130,15 +130,15 @@ mod_customize_coc_thresholds_server <- function(id, user_coc, nav_control, modul
       removeModal()
       req(nchar(trimws(input$custom_threshold_text)) > 0)
       
-      current_date_updated_for_threshold <- all_coc_thresholds()[ 
+      current_version_id_for_threshold <- all_coc_thresholds()[ 
         threshold_text == input$custom_threshold_text
-      ]$threshold_date_updated
+      ]$threshold_version_id
       
       updated_custom_threshold <- list(
         user_coc$coc_version_id, 
         input$custom_threshold_text,
         user_coc$username,
-        if (length(current_date_updated_for_threshold) > 0) current_date_updated_for_threshold else NA
+        if (length(current_version_id_for_threshold) > 0) current_version_id_for_threshold else NA
       )
       
       # These don't need to be tied together, but it avoids dealing with 2 different conflicts
@@ -151,7 +151,7 @@ mod_customize_coc_thresholds_server <- function(id, user_coc, nav_control, modul
             selected = TRUE,
             created_by = user_coc$username
           ) |>
-          fselect(threshold_id, coc_version_id, selected, created_by, date_updated)
+          fselect(threshold_id, coc_version_id, selected, created_by, version_id)
 
         needs_refresh2 <- update_selected_thresholds_db(p, updated_selected_thresholds)
       })

--- a/R/04a1b_mod_customize_rating_factors.R
+++ b/R/04a1b_mod_customize_rating_factors.R
@@ -420,7 +420,7 @@ mod_customize_rating_factors_server <- function(id, user_coc, funding_action, na
           goal = as.character(input[[paste0("goal_", id)]]),
           max_point_value = as.numeric(input[[paste0("points_", id)]]),
           created_by = user_coc$username,
-          date_updated = all_coc_factors()[rating_factor_id == id]$date_updated
+          version_id = all_coc_factors()[rating_factor_id == id]$version_id
         )
       }))
       
@@ -463,7 +463,7 @@ mod_customize_rating_factors_server <- function(id, user_coc, funding_action, na
                 cbind(inserted_custom_factor_info),
               fill = TRUE
             ) |>
-            fselect(rating_factor_id, coc_version_id, selected, goal, max_point_value, created_by, date_updated)
+            fselect(rating_factor_id, coc_version_id, selected, goal, max_point_value, created_by, version_id)
         }
         
         needs_refresh2 <- update_selected_rating_factors_db(p, updated_selected_rating_factors)

--- a/R/04a2_mod_thresholds_entry.R
+++ b/R/04a2_mod_thresholds_entry.R
@@ -198,7 +198,7 @@ mod_thresholds_entry_server <- function(id, user_coc, selected_project, selected
           project_id = params$project_id
         ) |>
         fsubset(met_threshold_new != fcoalesce(as.logical(met_threshold), FALSE)) |>
-        fselect(project_id, threshold_id, met_threshold_new, created_by, date_updated)
+        fselect(project_id, threshold_id, met_threshold_new, created_by, version_id)
     }
     get_updated_project_evaluation <- function(params) {
       data.table(
@@ -206,9 +206,9 @@ mod_thresholds_entry_server <- function(id, user_coc, selected_project, selected
         met_HUD_thresholds = params$met_all_HUD_requirements,
         met_CoC_thresholds = params$met_all_CoC_requirements,
         created_by = params$username,
-        date_updated = params$date_updated
+        version_id = params$version_id
       ) |>
-        fselect(project_id, met_HUD_thresholds, met_CoC_thresholds, created_by, date_updated)
+        fselect(project_id, met_HUD_thresholds, met_CoC_thresholds, created_by, version_id)
     }
     
     observeEvent(input$save_requirements, {
@@ -230,10 +230,10 @@ mod_thresholds_entry_server <- function(id, user_coc, selected_project, selected
           met_all_HUD_requirements = input$yes_to_all_HUD,
           met_all_CoC_requirements = input$yes_to_all_CoC,
           username = user_coc$username,
-          date_updated = ifelse(
-            is_empty(project_evaluation()$date_updated), 
+          version_id = ifelse(
+            is_empty(project_evaluation()$version_id), 
             NA, 
-            project_evaluation()$date_updated
+            project_evaluation()$version_id
           )
         )
       )

--- a/R/04a3_mod_rating_scores_entry.R
+++ b/R/04a3_mod_rating_scores_entry.R
@@ -244,7 +244,7 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, modul
         project_id = params$project_id,
         weighted_score = params$weighted_score,
         created_by = params$username,
-        date_updated = params$date_updated
+        version_id = params$version_id
       )
     }
     
@@ -260,7 +260,7 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, modul
         rating_scores               = sapply(selected_ids, \(id) input[[paste0("rating_score_", id)]]),
         performances                = sapply(selected_ids, \(id) input[[paste0("performance_", id)]]),
         created_bys                 = alloc(user_coc$username, num_selected),
-        date_updated                = df$date_updated
+        version_id                = df$version_id
       )
       
       
@@ -273,7 +273,7 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, modul
           project_id =  selected_project()$project_id,
           weighted_score = round(100 * numerator/denominator, 0),
           username = user_coc$username,
-          date_updated = project_evaluation()$date_updated
+          version_id = project_evaluation()$version_id
         )
       )
       

--- a/R/04b_mod_alternative_rating.R
+++ b/R/04b_mod_alternative_rating.R
@@ -205,7 +205,7 @@ debugger;
           met_hud_thresholds = ifelse(is.na(met_hud_thresholds), NA, ifelse(met_hud_thresholds == 'Yes', TRUE, FALSE)),
           met_coc_thresholds = ifelse(is.na(met_coc_thresholds), NA, ifelse(met_coc_thresholds == 'Yes', TRUE, FALSE))
         ) |>
-        fselect(project_id, met_hud_thresholds, met_coc_thresholds, weighted_score, created_by, date_updated)
+        fselect(project_id, met_hud_thresholds, met_coc_thresholds, weighted_score, created_by, version_id)
     }
     
     observeEvent(input$save_rating, {

--- a/R/app_db_funcs/db_01_mod_dashboard.R
+++ b/R/app_db_funcs/db_01_mod_dashboard.R
@@ -5,6 +5,7 @@ get_all_coc_versions_and_users <- function(username) {
     LEFT JOIN coc_version_users u ON v.coc_version_id = u.coc_version_id
     LEFT JOIN cocs c ON v.coc = c.coc_code"
   ) |>
+    fselect(-dv_ard) |>
     fmutate(
       coc_version_role = get_lookup_label(coc_version_role, 'coc_version_role'),
       coc_status = get_lookup_label(coc_status, 'coc_status')

--- a/R/app_db_funcs/db_01b_mod_requests.R
+++ b/R/app_db_funcs/db_01b_mod_requests.R
@@ -11,6 +11,7 @@ get_all_requests <- function(username) {
       cvr.created_by, 
       cvr.date_created, 
       cvr.request_status,
+      cvr.version_id,
       cvr.date_updated
     FROM coc_version_requests cvr 
     LEFT JOIN coc_versions cv ON cvr.coc_version_id = cv.coc_version_id
@@ -30,8 +31,13 @@ update_request_status <- function(p, update_params) {
   DBI::dbExecute(
     p,
     "UPDATE coc_version_requests 
-    SET request_status = $1, updated_by = $2, reason_for_rejection = $3, date_updated = CURRENT_TIMESTAMP
-    WHERE coc_request_id = $4 AND date_updated = $5",
+    SET 
+      request_status = $1, 
+      updated_by = $2, 
+      reason_for_rejection = $3, 
+      date_updated = CURRENT_TIMESTAMP, 
+      version_id = version_id + 1
+    WHERE coc_request_id = $4 AND version_id = $5",
     params = paramify(update_params)
   )
 }

--- a/R/app_db_funcs/db_03_mod_funding_priorities.R
+++ b/R/app_db_funcs/db_03_mod_funding_priorities.R
@@ -9,7 +9,7 @@ get_coc_funding_priorities <- function(coc_version_id) {
 
 get_coc_nofo_opportunities <- function(coc_version_id) {
   get_db_query(
-    "SELECT c.coc_nofo_opportunity_id, c.bonus_type, s.selected, s.date_updated
+    "SELECT c.coc_nofo_opportunity_id, c.bonus_type, s.selected, s.version_id
             FROM coc_nofo_opportunities c
             LEFT JOIN selected_coc_nofo_opportunities s ON c.coc_nofo_opportunity_id = s.coc_nofo_opportunity_id AND coc_version_id = $1", 
     params = list(coc_version_id)

--- a/R/app_db_funcs/db_04a1a_mod_customize_coc_thresholds.R
+++ b/R/app_db_funcs/db_04a1a_mod_customize_coc_thresholds.R
@@ -1,17 +1,13 @@
 get_all_coc_thresholds <- function(coc_version_id) {
   get_db_query(
-    "SELECT t.threshold_id, t.threshold_text, st.selected, t.date_updated AS threshold_date_updated, st.date_updated AS selected_threshold_date_updated
+    "SELECT t.threshold_id, t.threshold_text, st.selected, t.version_id AS threshold_version_id, st.version_id AS selected_threshold_version_id
         FROM thresholds t
         LEFT JOIN selected_thresholds st ON t.threshold_id = st.threshold_id AND st.coc_version_id = $1
         WHERE t.type = 'CoC' AND 
           (t.coc_version_id = $1 OR t.coc_version_id IS NULL)
         ORDER BY t.threshold_id",
     params = list(coc_version_id)
-  ) |>
-    fmutate(
-      threshold_date_updated = as.character(threshold_date_updated, tz = "UTC"),
-      selected_threshold_date_updated = as.character(selected_threshold_date_updated, tz = "UTC")
-    )
+  )
 }
 
 update_thresholds_db <- function(p, updated_thresholds) {
@@ -23,7 +19,7 @@ update_thresholds_db <- function(p, updated_thresholds) {
             ON CONFLICT (coc_version_id, threshold_text) DO UPDATE SET
               updated_by = EXCLUDED.created_by
           " |> add_optimistic_locking(),
-      "\nRETURNING threshold_id, coc_version_id, date_updated"
+      "\nRETURNING threshold_id, coc_version_id, version_id"
     ),
     updated_thresholds,
     "thresholds"

--- a/R/app_db_funcs/db_04a1b_mod_customize_rating_factors.R
+++ b/R/app_db_funcs/db_04a1b_mod_customize_rating_factors.R
@@ -1,7 +1,7 @@
 get_all_coc_factors <- function(funding_action_id, coc_version_id) {
   get_db_query(
     "SELECT rf.rating_factor_id, rf.funding_action, srf.selected, rf.project_type, rf.target_population, rf.rating_factor_text, COALESCE(srf.goal, rf.goal) AS goal,
-           COALESCE(srf.max_point_value, rf.max_point_value) AS max_point_value, fg.factor_group, fsg.factor_subgroup, srf.date_updated
+           COALESCE(srf.max_point_value, rf.max_point_value) AS max_point_value, fg.factor_group, fsg.factor_subgroup, srf.version_id
     FROM rating_factors rf
     FULL JOIN factor_groups fg ON rf.factor_group = fg.factor_group_id
     LEFT JOIN factor_subgroups fsg ON rf.factor_subgroup = fsg.factor_subgroup_id

--- a/R/app_db_funcs/db_04a2_mod_thresholds_entry.R
+++ b/R/app_db_funcs/db_04a2_mod_thresholds_entry.R
@@ -1,6 +1,6 @@
 get_all_thresholds_to_enter <- function(coc_version_id, project_id) {
   get_db_query(
-    "SELECT st.selected_threshold_id, st.selected, t.type, t.threshold_text, t.threshold_id, te.met_threshold, te.threshold_entry_id, te.date_updated
+    "SELECT st.selected_threshold_id, st.selected, t.type, t.threshold_text, t.threshold_id, te.met_threshold, te.threshold_entry_id, te.version_id
     FROM thresholds t
     LEFT JOIN selected_thresholds st ON st.threshold_id = t.threshold_id 
       AND st.coc_version_id = $1

--- a/R/app_db_funcs/db_04a3_mod_rating_scores_entry.R
+++ b/R/app_db_funcs/db_04a3_mod_rating_scores_entry.R
@@ -15,7 +15,7 @@ get_rating_factors_and_scores <- function(coc_version_id, selected_project) {
       fg.factor_group, fsg.factor_subgroup, 
       sr.goal, sr.max_point_value,
       rs.rating_score, rs.performance, rs.project_id,
-      rs.date_updated
+      rs.version_id
     FROM rating_factors r
     INNER JOIN selected_rating_factors sr ON sr.rating_factor_id = r.rating_factor_id AND sr.coc_version_id = $1
     JOIN factor_groups fg ON r.factor_group = fg.factor_group_id

--- a/R/app_db_funcs/db_04a_mod_in_app_rating.R
+++ b/R/app_db_funcs/db_04a_mod_in_app_rating.R
@@ -1,7 +1,7 @@
 # Used to pull project-evaluation info for a given project
 get_project_evaluation <- function(coc_version_id, project_id) {
   get_db_query(
-    "SELECT p.coc_version_id, pe.project_id, method, met_hud_thresholds, met_coc_thresholds, pe.date_updated 
+    "SELECT p.coc_version_id, pe.project_id, method, met_hud_thresholds, met_coc_thresholds, pe.version_id 
     FROM project_evaluations pe
     LEFT JOIN projects p ON pe.project_id = p.project_id
     WHERE p.coc_version_id = $1 and pe.project_id = $2",

--- a/R/app_db_funcs/db_04b_mod_alternative_rating.R
+++ b/R/app_db_funcs/db_04b_mod_alternative_rating.R
@@ -12,7 +12,7 @@ get_alternative_rating <- function(coc_version_id) {
       pe.met_hud_thresholds,
       pe.met_coc_thresholds,
       pe.weighted_score,
-      pe.date_updated
+      pe.version_id
     FROM projects p
     LEFT JOIN project_evaluations pe ON p.project_id = pe.project_id
     LEFT JOIN lookups l ON p.funding_action = l.reference_id

--- a/R/utils/data_manipulations.R
+++ b/R/utils/data_manipulations.R
@@ -222,7 +222,7 @@ format_timestamp <- function(t) {
 
 
 get_db_timestamp <- function() {
-  as.character(Sys.time())
+  format_timestamp(Sys.time())
 }
 
 save_to_db <- function(p, sql, params, tbl_name) {

--- a/R/utils/data_manipulations.R
+++ b/R/utils/data_manipulations.R
@@ -288,10 +288,11 @@ add_optimistic_locking <- function(sql) {
   
   # 3. Append date_updated and WHERE clause
   sql_with_locking <- glue::glue(
-    "{trimws(sql, which = 'right')},\n",
-    "            date_updated = CURRENT_TIMESTAMP",
-    "          WHERE {tbl_name}.date_updated = ${n + 1} ",
-    "OR (${n + 1} IS NULL AND {tbl_name}.date_updated IS NULL)"
+    "  {trimws(sql, which = 'right')},\n
+      date_updated = CURRENT_TIMESTAMP,
+      version_id = version_id + 1,
+    WHERE {tbl_name}.version_id = ${n + 1}
+      OR (${n + 1} IS NULL AND {tbl_name}.version_id IS NULL)"
   )
   
   sql_with_locking

--- a/R/utils/data_manipulations.R
+++ b/R/utils/data_manipulations.R
@@ -210,8 +210,7 @@ insert_and_return <- function(p, table, new_dt, return_cols) {
     ), 
     params = paramify(new_dt)
   ) |>
-    qDT() |>
-    convert_timestamps_to_char()
+    qDT()
   
   return(results)
 }
@@ -301,7 +300,7 @@ add_optimistic_locking <- function(sql) {
   sql_with_locking <- glue::glue(
     "  {trimws(sql, which = 'right')},\n
       date_updated = CURRENT_TIMESTAMP,
-      version_id = version_id + 1,
+      version_id = version_id + 1
     WHERE {tbl_name}.version_id = ${n + 1}
       OR (${n + 1} IS NULL AND {tbl_name}.version_id IS NULL)"
   )

--- a/R/utils/db_connect.R
+++ b/R/utils/db_connect.R
@@ -101,7 +101,8 @@ get_postgres_db <- function() {
     port = as.integer(Sys.getenv("AWS_RDS_PORT", "3306")),
     dbname = Sys.getenv(ifelse(IN_PROD_APP(), "AWS_RDS_DBNAME", "AWS_RDS_DBNAME_DEV")),
     user = Sys.getenv("AWS_RDS_USERNAME"),
-    password = Sys.getenv("AWS_RDS_PASSWORD")
+    password = Sys.getenv("AWS_RDS_PASSWORD"),
+    sslmode = "require"
   )
 } 
 

--- a/R/utils/get_db_data.R
+++ b/R/utils/get_db_data.R
@@ -29,12 +29,11 @@ get_db_tbl <- function(tbl_name) {
     })
     
     tbl <- tbl |> 
-      qDT() |>
-      convert_timestamps_to_char()
+      qDT()
     
     return(tbl)
   }, error = function(e) {
-    log_error(paste0(sql, e$message))
+    log_error(paste0("Importing ", tbl_name, e$message))
     list(ok = FALSE, error = e$message)
   })
 }

--- a/R/utils/get_db_data.R
+++ b/R/utils/get_db_data.R
@@ -1,14 +1,4 @@
 
-convert_timestamps_to_char <- function(dt) {
-  if("date_created" %in% names(dt)) 
-    dt[, date_created := as.character(date_created, tz = "UTC")]
-  
-  if("date_updated" %in% names(dt)) 
-    dt[, date_updated := as.character(date_updated, tz = "UTC")]
-  
-  return(dt)
-}
-
 # Get DB data ------------------
 get_db_query <- function(sql, params = NULL) {
   tryCatch({
@@ -18,11 +8,8 @@ get_db_query <- function(sql, params = NULL) {
         sql,
         params = params
       )
-    })
-    
-    dt <- dt |> 
-      qDT() |>
-      convert_timestamps_to_char()
+    }) |> 
+      qDT()
     
     return(dt)
   }, error = function(e) {

--- a/R/utils/user_settings.R
+++ b/R/utils/user_settings.R
@@ -32,7 +32,7 @@ update_single_user_setting <- function(p, user_coc, setting_nm, setting_val){
               setting_value = EXCLUDED.setting_value,
               updated_by = EXCLUDED.created_by,
               date_updated = CURRENT_TIMESTAMP",
-      "\nRETURNING user_setting_id, setting_name, setting_value, date_updated"
+      "\nRETURNING user_setting_id, setting_name, setting_value, version_id"
     ),
     updated_settings,
     "user_settings"

--- a/database/populate_db.R
+++ b/database/populate_db.R
@@ -1352,6 +1352,16 @@ CREATE TABLE IF NOT EXISTS ranking (
 );
 "))
 
+################
+# ADD VERSION ID
+# (for optimistic locking)
+#################
+tables <- DBI::dbListTables(get_db_pool())
+tables <- setdiff(tables, c("sqlite_sequence"))
+for(t in tables) {
+  DBI::dbExecute(get_db_pool(),  glue::glue("ALTER TABLE {t} ADD COLUMN version_id INTEGER NOT NULL DEFAULT 0;"))
+}
+
 #################
 # CREATE INDEXES
 ###############

--- a/sandbox/generate_test_data_for_demo.R
+++ b/sandbox/generate_test_data_for_demo.R
@@ -71,8 +71,6 @@ coc_versions <- data.table(
     second_user,
     second_user
   ),
-  date_created = get_db_timestamp(),
-  date_updated = get_db_timestamp(),
   updated_by = main_user
 )
 
@@ -92,8 +90,6 @@ coc_version_users <- data.table(
     main_user,
     second_user
   ),
-  date_created = get_db_timestamp(),
-  date_updated = get_db_timestamp(),
   updated_by = main_user
 )
 
@@ -114,8 +110,8 @@ coc_version_requests <- data.table(
     main_user,
     main_user
   ),
-  date_created = format(Sys.time() - c(86400, 43200, 86300, 43200), "%Y-%m-%d %H:%M:%S"),  # 1 day ago, 12 hours ago
-  date_updated = format(Sys.time() - c(86400, 43200, 86300, 43200), "%Y-%m-%d %H:%M:%S"),
+  date_created = Sys.time() - c(86400, 43200, 86300, 43200),  # 1 day ago, 12 hours ago
+  date_updated = Sys.time() - c(86400, 43200, 86300, 43200),
   updated_by = main_user
 )
 
@@ -176,10 +172,10 @@ for (i in 1:nrow(coc_versions)) {
   filtered_data <- get_hic_data(current_row$coc, current_row$coc_version_id)
   num_projects <- fnrow(filtered_data)
 
+  ids <- if(total_projects == 0) seq(1, num_projects) else seq(total_projects + 1, total_projects + num_projects)
+  
   filtered_data <- filtered_data |>
-    fmutate(project_id = -1*
-      if(total_projects == 0) seq(1, num_projects) else seq(total_projects + 1, total_projects + num_projects)
-    )
+    fmutate(project_id = -1*ids)
   
   total_projects <- total_projects + num_projects
 


### PR DESCRIPTION
finally biting the bullet and moving to version_id, instead of date_updated for optimistic locking. it wasn't working with sqlite because of date/timestamp format mismatches.