### PR TITLE
Hotfix/validate grant number

### DIFF
--- a/R/02_mod_inventory.R
+++ b/R/02_mod_inventory.R
@@ -421,6 +421,14 @@ mod_inventory_server <- function(id, nav_control, user_coc, parent_session, modu
       
       col_name <- colnames(projects_data())[info$col + 1]
       
+      if(col_name == "grant_number") {
+        if (nchar(info$value) > 15) {
+          showNotification("Grant number cannot be longer than 15 characters.", type = "error")
+          revert_cell(ns("projects_table"), info, input$projects_table_rows_current, projects_data())
+          return()
+        }
+      }
+      
       # numeric validation
       if (is.numeric(projects_data()[[col_name]])) {
         is_valid <- validate_numeric_entry(projects_data(), col_name, info$value)

--- a/R/02_mod_inventory.R
+++ b/R/02_mod_inventory.R
@@ -416,7 +416,6 @@ mod_inventory_server <- function(id, nav_control, user_coc, parent_session, modu
       
       info <- input$projects_table_cell_edit
       
-      req(info$value != "" && !is.null(info$value))
       req(!identical(info$value, info$oldValue))
       
       col_name <- colnames(projects_data())[info$col + 1]

--- a/www/custom.css
+++ b/www/custom.css
@@ -45,6 +45,11 @@ td.disabled {
   height: 38vh !important;
 }
 
+th[aria-label^="Grant Number"] {
+  min-width: fit-content;
+    white-space: nowrap;
+}
+
 /*the container div of the field control dropdown on Inventory*/
 /*positioning so search bar is in line with it*/
 #inventory-field_display_control_state {


### PR DESCRIPTION
- validate grant number (by length, which should be 15 characters)
- also fix column resizing during editing. Because Grant Number can wrap, the browser was pushing it to do so in order to make way more room for the longer headers. Thus the textbox was only 8-9 chars long and the cell itself when selected didn't align with the headers, causing the rest to be unaligned.