### PR TITLE
dv_ard fixes:

### DIFF
--- a/R/03_mod_funding_priorities.R
+++ b/R/03_mod_funding_priorities.R
@@ -31,14 +31,11 @@ mod_funding_priorities_ui <- function(id) {
   ]
   
   funding_input <- function(id, label) {
-    shinyWidgets::autonumericInput(
+    shinyWidgets::currencyInput(
       ns(id), 
-      label, 
+      label,
       value = "0",
-      currencySymbol = "$", 
-      currencySymbolPlacement = "p", 
-      decimalPlaces = 0, 
-      style="font-size:1em;"
+      format = "dollar"
     )
   }
   
@@ -132,6 +129,9 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
     coc_funding_priorities <- reactiveVal()
     formatted_coc_funding_priorities <- reactiveVal()
     
+    dv_ard <- reactive({ input$dv_ard })
+    dv_ard_debounced <- dv_ard %>% debounce(1000)
+    
     # Populate Funding Info -----------
     ard_field_names <- c(
       "total_ard",
@@ -145,19 +145,20 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
     )
     
     hud_ard_coc_data <- reactive({
+      dv_ard <- get_db_query("SELECT dv_ard FROM coc_versions WHERE coc_version_id = $1", params = user_coc$coc_version_id)
       HUD_ARD_REPORT[coc == user_coc$coc] |>
         fmutate(
           adjusted_ard = round(tier_1/0.9, 0),
           tier_2 = adjusted_ard * 0.1 + fcoalesce(coc_bonus, 0L) + fcoalesce(dv_bonus, 0L),
           yhdp_ard = estimated - min(adjusted_ard, estimated),
-          dv_ard = as.numeric(NA)
+          dv_ard = dv_ard[1]
         ) |>
         frename(estimated = "total_ard")
     })
     
     observeEvent(user_coc$coc, {
       lapply(ard_field_names, function(i) {
-        updateAutonumericInput(
+        updateCurrencyInput(
           session, 
           i, 
           value = hud_ard_coc_data()[[i]]
@@ -166,13 +167,20 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
       })
     })
     
-    observeEvent(input$dv_ard, {
+    iv <- shinyvalidate::InputValidator$new()
+    iv$add_rule("dv_ard", sv_gte(0))
+    
+    observeEvent(dv_ard_debounced(), {
       req(user_coc$coc)
+      iv$enable()
+      req(iv$is_valid())
+      iv$disable()
+      
       update_dv_ard(
         get_db_pool(),
-        list(input$dv_ard, user_coc$username, user_coc$coc)
+        list(dv_ard_debounced(), user_coc$username, user_coc$coc_version_id)
       )
-    })
+    }, ignoreInit = TRUE)
     
     
     # Priorities ------------

--- a/R/app_db_funcs/db_03_mod_funding_priorities.R
+++ b/R/app_db_funcs/db_03_mod_funding_priorities.R
@@ -46,15 +46,24 @@ update_coc_funding_priorities_db <- function(p, metric_name, updated_coc_funding
 }
 
 update_dv_ard <- function(p, params) {
-  save_to_db(
-    p,
-    "UPDATE hud_ard_report 
-    SET 
-      dv_ard = $1, 
-      updated_by = $2, 
-      date_updated = CURRENT_TIMESTAMP
-    WHERE coc = $3",
-    params,
-    "hud_ard_report"
-  )
+  # TODO: NEED TO ADD OPTIMISITC LOCKING
+  tryCatch({
+    DBI::dbExecute(
+      p,
+      "UPDATE coc_versions 
+      SET 
+        dv_ard = $1, 
+        updated_by = $2, 
+        date_updated = CURRENT_TIMESTAMP
+      WHERE coc_version_id = $3",
+      paramify(params)
+    )
+    message("Saved DV ARD!")
+  }, error = function(e) {
+    # If an error occurs, do NOT reset the flag, so it will try again.
+    # Notify the user of the failure.
+    showNotification(glue::glue("Error saving dv_ard to coc_versions table: {e$message}"), type = "error", duration = 10)
+    log_error(e$message)
+    stop(e) # rethrow error so the transaction can catch it and roll back
+  })
 }

--- a/database/populate_db.R
+++ b/database/populate_db.R
@@ -491,8 +491,7 @@ CREATE TABLE IF NOT EXISTS hud_ard_report (
     tier_1 INTEGER,
     coc_bonus INTEGER NULL,
     dv_bonus INTEGER,
-    coc_planning INTEGER,
-    dv_ard INTEGER
+    coc_planning INTEGER
 );
 ")
 
@@ -552,7 +551,8 @@ CREATE TABLE IF NOT EXISTS coc_versions (
     date_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     created_by VARCHAR(100) REFERENCES users(username) ON DELETE CASCADE,
     date_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_by VARCHAR(100) NULL REFERENCES users(username) ON DELETE CASCADE
+    updated_by VARCHAR(100) NULL REFERENCES users(username) ON DELETE CASCADE,
+    dv_ard INTEGER
 );
 "))
 


### PR DESCRIPTION
- using currencyInput to take advantage of defaults.
- adding a debounce trigger sincem by default, shiny widgets trigger observeEvents after every key stroke. This way, it waits 1 second so we push fewer changes.
- also, the dv_Ard field needs to live in the coc_versions table, not the hud_Ard_report. The latter is at the coc-level, not the coc-version-level.
- adding validation