### PR TITLE
Hotfix/rating entry totals

### DIFF
--- a/R/04a3_mod_rating_scores_entry.R
+++ b/R/04a3_mod_rating_scores_entry.R
@@ -170,7 +170,7 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, modul
                     max = max_points
                   )) |>
                     tagAppendAttributes(class = 'score-input', `data-group` = group_id),
-                p(paste("out of", max_points))
+                p(paste("out of", max_points), style="padding-top: 5px;")
               )
             }
           )
@@ -209,8 +209,11 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, modul
           layout_columns(
             col_widths = c(5, -2, -2, 1, 2),
             strong(paste0(group_name, " Subtotal")),
-            div(style = "text-align:center;", class = "subtotal-column", strong(class = "subtotal-display", `data-subtotal-for` = group_id, "0")),
-            div(strong(paste("out of", sum(group_dt$max_point_value, na.rm = TRUE)))) # Example
+            div(style = "text-align:center;", class = "subtotal-column", 
+                strong(textOutput(ns(paste0("subtotal_", group_id)), inline = TRUE))),
+            
+            # div(style = "text-align:center;", class = "subtotal-column", strong(class = "subtotal-display", `data-subtotal-for` = group_id, "0")),
+            div(strong(textOutput(ns(paste0("subtotal_max_", group_id)), inline=TRUE))) # Example
           )
         )
       })
@@ -231,6 +234,41 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, modul
         \(id) input[[paste0("rating_score_", id)]]
       )
     })
+    
+    # Dynamically update subgroup totals
+    observe({
+      req(nrow(factors_and_scores_for_project()) > 0)
+      
+      # Get the data and split it by group, just like in your UI
+      df <- factors_and_scores_for_project()
+      grouped_data <- split(df, by = "factor_group")
+      
+      # Loop through each group
+      lapply(names(grouped_data), function(group_name) {
+        
+        group_id <- make.names(group_name)
+        factor_ids <- grouped_data[[group_name]]$selected_rating_factor_id
+        
+        # Dynamically bind a renderText to the output
+        output[[paste0("subtotal_", group_id)]] <- renderText({
+          
+          # Grab the current values of all inputs in this specific group
+          current_scores <- sapply(factor_ids, function(id) {
+            val <- input[[paste0("rating_score_", id)]]
+            # Treat NULL, NA, or non-numeric as 0
+            if (is.null(val) || is.na(val)) 0 else as.numeric(val)
+          })
+          
+          # Return the sum
+          sum(current_scores)
+        })
+        
+        output[[paste0("subtotal_max_", group_id)]] <- renderText({
+          paste0("out of ", fsum(grouped_data[[group_name]]$max_point_value))
+        })
+      })
+    })
+    
     
     # Disable save_rating if any invalid responses
     observe({
@@ -273,7 +311,7 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, modul
           project_id =  selected_project()$project_id,
           weighted_score = round(100 * numerator/denominator, 0),
           username = user_coc$username,
-          date_updated = project_evaluation()$date_updated
+          date_updated = ifelse(fnrow(project_evaluation()) > 0, project_evaluation()$date_updated, NA)
         )
       )
       

--- a/R/04a3_mod_rating_scores_entry.R
+++ b/R/04a3_mod_rating_scores_entry.R
@@ -21,6 +21,8 @@ mod_rating_scores_entry_ui <- function(id) {
     card(
       uiOutput(ns("project_rating_factors")),
       card(
+        id = ns("total_row"),
+        style = "display:none;",
         layout_columns(
           col_widths = c(5, 2, 2, 1, 2),
           div(strong("Total")),
@@ -29,6 +31,19 @@ mod_rating_scores_entry_ui <- function(id) {
           div(style = "text-align:center;", 
               strong(textOutput(ns("total_score"), inline=TRUE))),
           div(strong(textOutput(ns("total_max"), inline=TRUE)))
+        )
+      ),
+      card(
+        id = ns("weighted_total_row"),
+        style = "display:none;",
+        layout_columns(
+          col_widths = c(5, 2, 2, 1, 2),
+          div(strong("Weighted Total")),
+          div(),
+          div(),
+          div(style = "text-align:center;", 
+              strong(textOutput(ns("weighted_total_score"), inline=TRUE))),
+          div(strong("out of 100"))
         )
       ),
       card_footer(
@@ -229,6 +244,12 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, modul
         )
       })
       
+      # Give shiny enough time to load factors before showing Total rows
+      delay(800, {
+        shinyjs::show(id = "total_row")
+        shinyjs::show(id = "weighted_total_row")
+      })
+      
       # The final accordion structure
       bslib::accordion(
         !!!accordion_items_group,
@@ -280,10 +301,17 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, modul
       })
       
       output$total_score <- renderText({
-        fsum(factors_and_scores_for_project()$rating_score)
+        fsum(entered_scores())
       })
       output$total_max <- renderText({
         paste0("out of ", fsum(factors_and_scores_for_project()$max_point_value))
+      })
+      
+      output$weighted_total_score <- renderText({
+        denominator <- fsum(factors_and_scores_for_project()$max_point_value)
+        numerator <- fsum(entered_scores())
+        
+        round(100 * numerator/denominator, 0)
       })
     })
     

--- a/R/04a3_mod_rating_scores_entry.R
+++ b/R/04a3_mod_rating_scores_entry.R
@@ -20,6 +20,17 @@ mod_rating_scores_entry_ui <- function(id) {
     )))),
     card(
       uiOutput(ns("project_rating_factors")),
+      card(
+        layout_columns(
+          col_widths = c(5, 2, 2, 1, 2),
+          div(strong("Total")),
+          div(),
+          div(),
+          div(style = "text-align:center;", 
+              strong(textOutput(ns("total_score"), inline=TRUE))),
+          div(strong(textOutput(ns("total_max"), inline=TRUE)))
+        )
+      ),
       card_footer(
         style = "display: flex; justify-content: space-between; align-items: center;",
         actionButton(ns("save_rating"), "Save Rating", icon = icon("save"))
@@ -266,6 +277,13 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, modul
         output[[paste0("subtotal_max_", group_id)]] <- renderText({
           paste0("out of ", fsum(grouped_data[[group_name]]$max_point_value))
         })
+      })
+      
+      output$total_score <- renderText({
+        fsum(factors_and_scores_for_project()$rating_score)
+      })
+      output$total_max <- renderText({
+        paste0("out of ", fsum(factors_and_scores_for_project()$max_point_value))
       })
     })
     

--- a/database/populate_db.R
+++ b/database/populate_db.R
@@ -1291,7 +1291,7 @@ CREATE TABLE IF NOT EXISTS rating_scores (
     rating_score_id {id_var_attrs},
     project_id INTEGER REFERENCES projects(project_id) ON DELETE CASCADE,
     selected_rating_factor_id SMALLINT NULL REFERENCES selected_rating_factors(selected_rating_factor_id) ON DELETE CASCADE, --can be null if they rate outside the app
-    rating_score INTEGER,
+    rating_score NUMERIC(4, 1) NULL,
     performance VARCHAR(100) NULL,
 	date_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     created_by VARCHAR(100) REFERENCES users(username) ON DELETE CASCADE,


### PR DESCRIPTION
- move "max points" down a bit to be more vertically aligned with rating score
- instead of JS-only group subtotals, use textOutputs. This makes it easier to understand and also will show the right total after a save or on load.
- handle null project_evaluation record. This was causing there to be an empty table for the update which causes update problems.
- allow decimals in rating score.
- add total and weighted total rows