### PR TITLE
funding priorities fixes:

### DIFF
--- a/R/03_mod_funding_priorities.R
+++ b/R/03_mod_funding_priorities.R
@@ -204,7 +204,8 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
         join(
           pop_grp_toggles |> fselect(Population = full_text, pop, grp),
           on = c("target_population" = "pop", "population_group" = "grp"),
-          how = "right"
+          how = "right",
+          multiple = TRUE
         ) |>
         fselect(Population, project_type, beds, funding, priority) |>
         # For each Population, get all main project types, still in long format
@@ -248,16 +249,6 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
       formatted_coc_funding_priorities(
         format_coc_funding_priorities(coc_funding_priorities())
       )
-      
-      ## Population toggles --------
-      selected_populations <- formatted_coc_funding_priorities() %>%
-        dplyr::filter(dplyr::if_any(-Population, ~ !is.na(.)))
-      
-      updateCheckboxGroupInput(
-        session,
-        "population_toggles",
-        selected = if(fnrow(selected_populations) > 0) selected_populations$Population else input$population_toggles
-      )
     })
     
     ## CoC NOFO Opportunities ------
@@ -299,8 +290,20 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
     
     
     # Priorities section -----------------
+    observeEvent(user_coc$coc_version_id, {
+      ## Population toggles --------
+      selected_populations <- formatted_coc_funding_priorities() %>%
+        dplyr::filter(dplyr::if_any(-Population, ~ !is.na(.)))
+      
+      updateCheckboxGroupInput(
+        session,
+        "population_toggles",
+        selected = if(fnrow(selected_populations) > 0) selected_populations$Population else  c("General Families", "General Individuals", "Single Youth")
+      )
+    })
     output$priorities_table <- renderDT({
-      req(coc_funding_priorities())
+      req(user_coc$coc_version_id)
+      req(formatted_coc_funding_priorities())
       
       show_priorities_row <- length(input$population_toggles) > 0
       
@@ -356,7 +359,8 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
           dom = 't',
           searching = FALSE,
           info = FALSE,
-          keys = TRUE
+          keys = TRUE,
+          ordering = FALSE
         ),
         filter = 'none',
         callback_js = glue::glue(
@@ -387,12 +391,12 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
       #end initialize_data_Table
     }, server = FALSE)
     
-    priorities_table_proxy <- dataTableProxy(ns("priorities_table"),session = session)
+    priorities_table_proxy <- dataTableProxy("priorities_table",session = session)
     
-    observe({
-      req(formatted_coc_funding_priorities())
-      replaceData(priorities_table_proxy, formatted_coc_funding_priorities(), resetPaging = FALSE)
-    })
+    # observe({
+    #   req(formatted_coc_funding_priorities())
+    #   replaceData(priorities_table_proxy, formatted_coc_funding_priorities(), resetPaging = FALSE)
+    # })
     
     
     # Update priorities data in table and db when cell is edited
@@ -449,7 +453,7 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
         )
       
       # bed, funding, or priority
-      metric_name <- names(changed_data)[3]
+      metric_name <- names(changed_data)[3] # 3rd col is always the metric (bed/funding/priority)
       
       if(metric_name == "priority") 
         changed_data <- changed_data |>
@@ -463,7 +467,7 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
         changed_data$population_group,
         changed_data[[metric_name]],
         user_coc$username,
-        date_updated = changed_data$date_updated
+        changed_data$date_updated
       )
       
       needs_refresh <- update_coc_funding_priorities_db(
@@ -475,7 +479,7 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
       # if(needs_refresh)
         refresh_trigger$coc_funding_priorities <- refresh_trigger$coc_funding_priorities + 1
       
-      formatted_coc_funding_priorities(current_data)
+      # formatted_coc_funding_priorities(current_data)
     }) # end observeEvent
     
     

--- a/R/03_mod_funding_priorities.R
+++ b/R/03_mod_funding_priorities.R
@@ -415,6 +415,8 @@ mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_sess
       
       # only proceed if they changed anything:
       old_val <- current_data[full_data_row_index, (info$col + 1), with=FALSE][[1]]
+      info$value <- DT::coerceValue(info$value, old_val)
+      
       req(!identical(old_val, info$value))
       
       col_name <- colnames(current_data)[info$col + 1]

--- a/www/custom.css
+++ b/www/custom.css
@@ -40,6 +40,9 @@ td.disabled {
 #funding_priorities-priorities_table table.dataTable td {
   text-align:center;
 }*/
+[id^="funding_priorities"].autonumeric-input {
+  font-size: 1.2rem !important; /*otherwise, default for currencyInput is 1.5rem which is too big*/
+}
 
 #inventory-projects_table .dataTables_scrollBody {
   height: 38vh !important;


### PR DESCRIPTION
- fix disappearing data by making sure the join on pop_grp_toggles allows for multiple. Otherwise, only PSH was working because it was the first project type.
- don't update pop toggles after refresh trigger, as this will lose data. It should only happen when they change coc versions
- default to the original 3 and don't make them disappear after changes to the table. This is confusing for the user.
- make sure priorities table is tied to coc_version_id so it will change when the version changes.
- since server=FALSE for the priorities table, let's fix the namespacing and remove the replaceData.
- disable sorting on priorities table. Not enough data or worth potential row indexing issues
- no need to update formatted_coc_funding_priorities after table edit. The refresh trigger will take care of that.
- remove extraneous value name when updating changed data.
- make bucket funding amounts 1.2rem. currencyInput defaults to 1.5rem which is too big