### PR TITLE
we don't want a conditional refresh. Otherwise, if they select "All" …

### DIFF
--- a/R/04b_mod_alternative_rating.R
+++ b/R/04b_mod_alternative_rating.R
@@ -171,7 +171,7 @@ debugger;
       updated_project_evaluations = get_updated_project_evaluations(user_coc$username, ratable_projects())
       needs_refresh <- update_project_evaluations_db(get_db_pool(), updated_project_evaluations)
       
-      if(needs_refresh)
+      # if(needs_refresh)
         refresh_trigger(\(x) x + 1)
     }
     


### PR DESCRIPTION
…for one column and were successful and then change another, the date_updated won't have updated so the 2nd call will always fail. Addresses HORRT-123-on-alternative-rating-page-the-all-and-none-buttons-do-not-set-all-projects-to-yes-or-no