### PR TITLE
Rating Entry page refreshes after coc_version switch

### DIFF
--- a/R/04a3_mod_rating_scores_entry.R
+++ b/R/04a3_mod_rating_scores_entry.R
@@ -137,8 +137,15 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project) {
     
     # Project Rating Factors UI
     output$project_rating_factors <- renderUI({
+      selected_project_exists <- !is.null(selected_project()) && fnrow(selected_project()) > 0
+      
+      if(!selected_project_exists) {
+        shinyjs::hide(id = "total_row")
+        shinyjs::hide(id = "weighted_total_row")
+      }
+      
       shiny::validate(need(
-        !is.null(selected_project()),
+        selected_project_exists,
         "Select a project in the left-hand sidebar to begin rating"
       ))
 

--- a/R/04a_mod_in_app_rating.R
+++ b/R/04a_mod_in_app_rating.R
@@ -75,6 +75,7 @@ mod_in_app_rating_server <- function(id, user_coc, funding_action, nav_control) 
     
     # Get the project to be rated from the dropdown in the sidebar
     selected_project <- reactive({
+      req(user_coc$coc_version_id)
       if (is.null(input$project_select) || input$project_select == "") return(NULL)
       
       all_projects() |> 

--- a/R/04b_mod_alternative_rating.R
+++ b/R/04b_mod_alternative_rating.R
@@ -225,6 +225,9 @@ debugger;
     
     # Save ----------------------
     get_updated_project_evaluations <- function(username, ratable_projects) {
+      message("In get updated project evaluation, ratable_projects:\n", 
+              paste(knitr::kable(ratable_projects), collapse = "\n"))
+      
       ratable_projects |>
         fmutate(
           created_by = username,

--- a/R/04b_mod_alternative_rating.R
+++ b/R/04b_mod_alternative_rating.R
@@ -228,8 +228,8 @@ debugger;
       ratable_projects |>
         fmutate(
           created_by = username,
-          met_hud_thresholds = ifelse(is.na(met_hud_thresholds), NA, ifelse(met_hud_thresholds == 'Yes', TRUE, FALSE)),
-          met_coc_thresholds = ifelse(is.na(met_coc_thresholds), NA, ifelse(met_coc_thresholds == 'Yes', TRUE, FALSE))
+          met_hud_thresholds = met_hud_thresholds == 'Yes',
+          met_coc_thresholds = met_coc_thresholds == 'Yes'
         ) |>
         fselect(project_id, met_hud_thresholds, met_coc_thresholds, weighted_score, created_by, date_updated)
     }

--- a/R/app_db_funcs/db_04b_mod_alternative_rating.R
+++ b/R/app_db_funcs/db_04b_mod_alternative_rating.R
@@ -23,6 +23,9 @@ get_alternative_rating <- function(coc_version_id) {
 
 
 update_project_evaluations_db <- function(p, updated_project_evaluation) {
+  message("Updated project evaluation:\n", 
+          paste(knitr::kable(updated_project_evaluation), collapse = "\n"))
+  
   save_to_db(
     p,
     "INSERT INTO project_evaluations (project_id, method, met_hud_thresholds, met_coc_thresholds, weighted_score, created_by)

--- a/R/utils/data_manipulations.R
+++ b/R/utils/data_manipulations.R
@@ -230,22 +230,22 @@ save_to_db <- function(p, sql, params, tbl_name) {
   if(purrr::every(paramified, is.null)) 
     return(FALSE)
   
-  save_func <- function() {
+  save_func <- function(conn) {
     if(!grepl("RETURNING ", sql)) {
-      DBI::dbExecute(p, sql, params = paramified)
+      DBI::dbExecute(conn, sql, params = paramified)
     } else {
-      DBI::dbGetQuery(p, sql, params = paramified)
+      DBI::dbGetQuery(conn, sql, params = paramified)
     }
   }
   tryCatch({
     # if not already inside a transaction (i.e. where p is a connection, wrap in transaction for speed)
     rows_changed <- if(inherits(p, "Pool")) {
       pool::poolWithTransaction(p, function(conn) {
-        save_func()
+        save_func(conn)
       })
     } else {
       # otherwise, we're in a transaction, so just save
-      save_func()
+      save_func(p)
     }
     
     if(grepl("RETURNING ", sql)) {


### PR DESCRIPTION
- this includes the weighted and total score rows which should at least hide if no project is selected
- it also makes selected_project reactive to the coc_Version_id