### PR TITLE
Feat/add delete version

### DIFF
--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -178,6 +178,8 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
     
     observeEvent(input$confirm_deletion, {
       delete_coc_version(user_coc$coc_version_id)
+      remove_modal()
+      refresh_trigger(\(x) x + 1)
     })
     
     ## Copy selected version ------------

--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -107,7 +107,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
     
     ## Selecting a version ------------
     observeEvent(input$coc_versions_dt_rows_selected, {
-      current_coc_info <- users_versions()[input$coc_versions_dt_rows_selected, .(coc, coc_version_id)]
+      current_coc_info <- users_versions()[input$coc_versions_dt_rows_selected, .(coc, coc_version_id, coc_version_role)]
       user_coc$coc <- current_coc_info$coc
       user_coc$coc_version_id <- current_coc_info$coc_version_id
       user_coc$date_updated <- current_coc_info$date_updated
@@ -116,7 +116,7 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
       toggle_navs_on_coc_selection()
       
       shinyjs::toggle(id = 'edit_coc_version', condition = length(input$coc_versions_dt_rows_selected) > 0)
-      shinyjs::toggle(id = 'delete_coc_version', condition = length(input$coc_versions_dt_rows_selected) > 0)
+      shinyjs::toggle(id = 'delete_coc_version', condition = length(input$coc_versions_dt_rows_selected) > 0 && current_coc_info$coc_version_role == "Owner")
       shinyjs::toggle(id = 'copy_version', condition = length(input$coc_versions_dt_rows_selected) > 0)
     }, ignoreNULL = FALSE)
     

--- a/R/01a_mod_coc_selection.R
+++ b/R/01a_mod_coc_selection.R
@@ -178,8 +178,8 @@ mod_coc_selection_server <- function(id, nav_control, user_coc, parent_session) 
     
     observeEvent(input$confirm_deletion, {
       delete_coc_version(user_coc$coc_version_id)
-      remove_modal()
-      refresh_trigger(\(x) x + 1)
+      removeModal()
+      refresh_trigger$versions <- refresh_trigger$versions + 1
     })
     
     ## Copy selected version ------------

--- a/database/populate_db.R
+++ b/database/populate_db.R
@@ -581,7 +581,7 @@ DBI::dbExecute(get_db_pool(), glue::glue("
 --- Advanced would allow them to select what to carry over
 CREATE TABLE IF NOT EXISTS coc_version_users (
     coc_version_user_id {id_var_attrs},
-    coc_version_id SMALLINT REFERENCES coc_versions(coc_version_id),
+    coc_version_id SMALLINT REFERENCES coc_versions(coc_version_id) ON DELETE CASCADE,
     username VARCHAR(100) REFERENCES users(username) ON DELETE CASCADE,
     coc_version_role SMALLINT REFERENCES lookups(reference_id), -- Changed to reference lookups
     date_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
- add ON DELETE CASCADE to coc_version users when coc_version is deleted. This should have been there but I'd missed it
- hide delete button from non-Owners