### PR TITLE
gracefully handle login and logout

### DIFF
--- a/R/00_mod_account.R
+++ b/R/00_mod_account.R
@@ -21,6 +21,17 @@ mod_account_ui <- function(id){
     #   value = "sign_up",
     #   tags$a("Create Account", id = "submit_sign_up", href = aws_auth_signup)
     # ),
+    tags$script(HTML(sprintf("
+    document.addEventListener('click', function(e) {
+      var el = e.target.closest('#submit_sign_out');
+      if (!el) return;
+      
+      e.preventDefault(); // stops the href navigation
+      
+      hide_disconnect();
+      
+      window.location.href = '%s';
+    });", aws_auth_logout))),
     nav_item(
       value = "user_details",
       textOutput(ns('username'))

--- a/R/00_mod_account.R
+++ b/R/00_mod_account.R
@@ -28,7 +28,10 @@ mod_account_ui <- function(id){
       
       e.preventDefault(); // stops the href navigation
       
-      hide_disconnect();
+      var style = document.createElement('style');
+      style.id = 'ss-hide-overlay-style';
+      style.innerHTML = '#ss-overlay, #ss-connect-dialog { display: none !important; }';
+      document.head.appendChild(style);
       
       window.location.href = '%s';
     });", aws_auth_logout))),

--- a/server.R
+++ b/server.R
@@ -86,6 +86,7 @@ function(input, output, session) {
         user_coc$username <- current_user$email
         user_coc$given_name <- current_user$given_name
         nav_control("dashboard")
+        session$sendCustomMessage("auth_state", TRUE)
       }
     }
     

--- a/ui.R
+++ b/ui.R
@@ -30,7 +30,7 @@ page_navbar(
         text-align:center;
         padding:20px;
       ",
-      "You have been logged out. Redirecting..."
+      "Session timed out. Logging out..."
     ),
     tags$style(HTML("
       /* Change the background color of the selected row */

--- a/ui.R
+++ b/ui.R
@@ -14,17 +14,105 @@ page_navbar(
     tags$head(
       tags$link(rel = "stylesheet", type = "text/css", href = "custom.css")
     ),
+    tags$div(
+      id = "logout-overlay",
+      style = "
+        display:none;
+        position:fixed;
+        top:0; left:0;
+        width:100%; height:100%;
+        background:rgba(0,0,0,0.75);
+        color:white;
+        font-size:20px;
+        align-items:center;
+        justify-content:center;
+        z-index:99999;
+        text-align:center;
+        padding:20px;
+      ",
+      "You have been logged out. Redirecting..."
+    ),
     tags$style(HTML("
-    /* Change the background color of the selected row */
-    table.dataTable tbody tr.selected>* {
-      box-shadow: inset 0 0 0 9999px #357DAD !important;
-      color: white;
-    }
-    table.dataTable.display > tbody > tr.selected:hover>* {
-      box-shadow: inset 0 0 0 9999px #357DAD !important;
-      color: white;
-    }
-  ")),
+      /* Change the background color of the selected row */
+      table.dataTable tbody tr.selected>* {
+        box-shadow: inset 0 0 0 9999px #357DAD !important;
+        color: white;
+      }
+      table.dataTable.display > tbody > tr.selected:hover>* {
+        box-shadow: inset 0 0 0 9999px #357DAD !important;
+        color: white;
+      }
+    ")),
+    tags$script(HTML(sprintf("
+     // 1. Hide any potential disconnect overlays
+     function hide_disconnect() {
+      var style = document.createElement('style');
+      style.id = 'ss-hide-overlay-style';
+      style.innerHTML = '#ss-overlay, #ss-connect-dialog { display: none !important; }';
+      document.head.appendChild(style);
+     }
+     
+     // HANDLE LOGIN (HIDE DISCONNECT AND REDIRECT)
+     document.addEventListener('click', function(e) {
+      var el = e.target.closest('#login_link');
+      if (!el) return;
+    
+      e.preventDefault(); // stops the href navigation
+    
+      hide_disconnect();
+    
+      window.location.href = '%s';
+    });
+     
+     // AUTH STATE
+     var logged_in = null;
+     var timeout = null;
+     var idleTimeout = 1000 * 60 * 9; //9 minutes
+     
+     // OVERLAY
+     function showLogoutOverlay() {
+       document.getElementById('logout-overlay').style.display = 'flex';
+       
+       setTimeout(function() {
+         window.location.href = '%s';
+       }, 1500);
+     }
+   
+     // TIMER LOGIC (GATED)
+     function resetTimer() {
+       if (logged_in !== true) return;
+       
+       clearTimeout(timeout);
+       
+       timeout = setTimeout(function() {
+         hide_disconnect();
+         showLogoutOverlay();
+       }, idleTimeout);
+     }
+     
+     // ACTIVITY HANDLER
+     function markActivity() {
+       if (logged_in !== true) return;
+       resetTimer();
+     }
+     
+     // SHINY AUTH MESSAGE - GET WHETHER USER LOGGED IN
+     Shiny.addCustomMessageHandler('auth_state', function(l) {
+       logged_in = l;
+       
+       // arm timer only after login confirmed
+       if (logged_in === true) resetTimer(); 
+       
+       document.getElementById('ss-hide-overlay-style')?.remove();
+     });
+     
+     // USER ACTIVITY EVENTS
+     var events = ['click', 'mousemove', 'keypress', 'scroll'];
+     
+     events.forEach(function(e) {
+       document.addEventListener(e, markActivity, { passive: true });
+     });
+     ", aws_auth_redirect, aws_auth_logout))),
     ## Enable shinyjs -----
     shinyjs::useShinyjs(),
     disconnectMessage(


### PR DESCRIPTION
All browsers, on redirect, disconnect the session. But Firefox is apparently slower and there's enough lag for the disconnect message to be visible.

1. When user logs in, before redirecting, we add css to hide the disconnect. When they're redirected back to the app, the css will be overwritten
2.  When they log in, we store that in a js variable and begin a idle timer. If they're idle for 9 minutes (which I think is just below the default of 10, so we can get a jump on handling it), we add the same css and show a custom logging out message overlay before logging them out
3. any action they take when logged in will reset the timer.