### PR TITLE
Hotfix/ratable projects

### DIFF
--- a/R/02a_mod_inventory_add_project.R
+++ b/R/02a_mod_inventory_add_project.R
@@ -223,7 +223,7 @@ mod_inventory_add_project_server <- function(
         else LOOKUP_CHOICES$all_project_types
       
       updateSelectInput(session, "project_type", choices = c("Select Funding Source first" = "", proj_type_choices), selected = input$project_type)
-    }, ignoreInit = FALSE, ignoreNULL = FALSE)
+    }, ignoreInit = TRUE, ignoreNULL = FALSE)
     
     # Update visibility based on funding action
     observeEvent(input$funding_action, {
@@ -242,7 +242,7 @@ mod_inventory_add_project_server <- function(
       vis_beds <- visible_bed_groups()
       all_bed_groups <- c("total_beds", "ch_beds", "vet_beds", "youth_beds")
       lapply(all_bed_groups, function(group) shinyjs::toggle(group, condition = group %in% vis_beds))
-    }, ignoreInit = FALSE, ignoreNULL = FALSE)
+    }, ignoreInit = TRUE, ignoreNULL = FALSE)
     
     # Update DV checkbox and related elements
     observeEvent(c(input$funding_action, input$project_type, current_target_pop()), {
@@ -264,7 +264,7 @@ mod_inventory_add_project_server <- function(
       
       # Missing organization_name state control
       shinyjs::toggleState("organization_name", condition = form_type() != "YHDP Replacement")
-    }, ignoreInit = FALSE, ignoreNULL = FALSE)
+    }, ignoreInit = TRUE, ignoreNULL = FALSE)
     
     # Update Target Population Selection
     observeEvent(current_target_pop(), {
@@ -273,7 +273,7 @@ mod_inventory_add_project_server <- function(
       shinyjs::toggleState("target_population", condition = TRUE) # start by enabling so we can set the value
       if (current_funding_source() != "CoC") updateSelectInput(session, "target_population", selected = tp)
       shinyjs::toggleState("target_population", condition = current_funding_source() %in% c("", "CoC"))
-    }, ignoreInit = FALSE, ignoreNULL = FALSE)
+    }, ignoreInit = TRUE, ignoreNULL = FALSE)
     
     # --- PSH Checkbox Logic ---
     observeEvent(input$targeted_ch_fam, 
@@ -288,11 +288,11 @@ mod_inventory_add_project_server <- function(
     observeEvent(c(input$total_beds_fam, input$ch_beds_fam), {
       is_equal <- input$total_beds_fam > 0 && input$total_beds_fam == input$ch_beds_fam
       updateCheckboxInput(session, "targeted_ch_fam", value = is_equal)
-    }, ignoreNULL = FALSE)
+    }, ignoreInit = TRUE, ignoreNULL = FALSE)
     observeEvent(c(input$total_beds_ind, input$ch_beds_ind), {
       is_equal <- input$total_beds_ind > 0 && input$total_beds_ind == input$ch_beds_ind
       updateCheckboxInput(session, "targeted_ch_ind", value = is_equal)
-    }, ignoreNULL = FALSE)
+    }, ignoreInit = TRUE, ignoreNULL = FALSE)
     
     # =================================================================
     # Validation & Submission

--- a/R/04a_mod_in_app_rating.R
+++ b/R/04a_mod_in_app_rating.R
@@ -36,7 +36,7 @@ mod_in_app_rating_server <- function(id, user_coc, funding_action, nav_control) 
     ## restore last selected project from user_settings DB tbl
     ## also update choices
     observe({
-      req(!is.null(user_coc$coc_version_id) & nav_control() == 'rating')
+      req(!is.null(user_coc$coc_version_id) & nav_control() == 'rating', user_coc$projects_updated)
       
       user_prev_project_selected <- get_user_setting(get_db_pool(), glue::glue('rating_{id}_project_selected'), user_coc$coc_version_id, user_coc$username)
       

--- a/R/global_data_prep.R
+++ b/R/global_data_prep.R
@@ -45,9 +45,9 @@ TABS_AFTER_PROJECTS_EXIST <- c(
 )
 
 RATABLE_PROJECT_TYPES <- list(
-  "New" = c("RRH","PSH", "TH+RRH"),
+  "New" = c("RRH","PSH", "TH+RRH", "TH"),
   "Renew" = c("RRH", "PSH", "TH","TH+RRH","OPH","DEM"),
-  "Expand" = c("RRH","PSH")
+  "Expand" = c("RRH","PSH", "TH")
 )
 
 


### PR DESCRIPTION
- allow TH projects to be rated for New and Expansions
- don't run add project modal observe events on app startup.
- make sure select project dropdown is updated after projects are added