### PR TITLE
misc fixes

### DIFF
--- a/R/02_mod_inventory.R
+++ b/R/02_mod_inventory.R
@@ -294,7 +294,7 @@ mod_inventory_server <- function(id, nav_control, user_coc, parent_session) {
     # By updating a proxy (via `replaceData`), updates are faster and don't "flicker" the table
     # However it doesn't work when adding new rows
     projects_table_proxy <- dataTableProxy("projects_table",session = session)
-    projects_table_proxy$id <- "projects_table"
+    projects_table_proxy$id <- "projects_table" # setting id to raw_id seems to fix auto-scrolling
     
     observe({
       req(projects_data())
@@ -342,24 +342,25 @@ mod_inventory_server <- function(id, nav_control, user_coc, parent_session) {
     
     # Update DT table with column changes made in dropdown (pickerInput)
     observeEvent(input$projects_col_selections, {
-      
-       req(user_coc$auth)
-       req(!is.null(user_coc$coc_version_id) & nav_control() == 'inventory')
-       req(projects_data())
+      req(user_coc$auth)
+      req(!is.null(user_coc$coc_version_id) & nav_control() == 'inventory')
+      req(projects_data())
         
-       cols_to_hide <- match(setdiff(names(projects_data()), input$projects_col_selections), names(projects_data())) - 1
-       cols_to_show <- which(names(projects_data()) %in% input$projects_col_selections) - 1
-       # or, equivalently: cols_to_show <- match(input$projects_col_selections, names(projects_data())) - 1
+      cols_to_hide <- match(setdiff(names(projects_data()), input$projects_col_selections), names(projects_data())) - 1
+      cols_to_show <- which(names(projects_data()) %in% input$projects_col_selections) - 1
+      # or, equivalently: cols_to_show <- match(input$projects_col_selections, names(projects_data())) - 1
+      
+      ## show and hide columns as needed
+      projects_table_proxy$id <- ns("projects_table")
+      if(length(cols_to_hide) > 0) {
+        hideCols(projects_table_proxy, hide = cols_to_hide)
+      }
+      if(length(cols_to_show) > 0) {
+        showCols(projects_table_proxy, show = cols_to_show)
+      }
+      projects_table_proxy$id <- "projects_table"
        
-       ## show and hide columns as needed
-        if(length(cols_to_hide) > 0){
-          hideCols(projects_table_proxy, hide = cols_to_hide)
-        }
-        if(length(cols_to_show) > 0){
-          showCols(projects_table_proxy, show = cols_to_show)
-        }
-       
-       user_coc$settings$cols_to_hide <- names(projects_data())[cols_to_hide+1]
+      user_coc$settings$cols_to_hide <- names(projects_data())[cols_to_hide+1]
     })
     
     # Update projects -----

--- a/R/02_mod_inventory.R
+++ b/R/02_mod_inventory.R
@@ -293,6 +293,7 @@ mod_inventory_server <- function(id, nav_control, user_coc, parent_session) {
     # By updating a proxy (via `replaceData`), updates are faster and don't "flicker" the table
     # However it doesn't work when adding new rows
     projects_table_proxy <- dataTableProxy("projects_table",session = session)
+    projects_table_proxy$id <- "projects_table"
     
     observe({
       req(projects_data())

--- a/R/02_mod_inventory.R
+++ b/R/02_mod_inventory.R
@@ -330,8 +330,8 @@ mod_inventory_server <- function(id, nav_control, user_coc, parent_session) {
       req(!is.null(user_coc$coc_version_id) & nav_control() == 'inventory')
       req(projects_data())
       
-      bed_fields <- grep('bed', names(projects_data())) - 1
-      bed_field_names <- names(projects_data())[bed_fields + 1]
+      bed_fields <- grep('bed', names(projects_data()))
+      bed_field_names <- names(projects_data())[bed_fields]
       
       if(input$toggle_bed_fields){
         updatePickerInput(session, inputId = 'projects_col_selections', selected = union(input$projects_col_selections, bed_field_names))

--- a/R/02_mod_inventory.R
+++ b/R/02_mod_inventory.R
@@ -266,7 +266,7 @@ mod_inventory_server <- function(id, nav_control, user_coc, parent_session) {
           
           function(x) formatRound(
             x,
-            columns = grep('bed', names(data)) - 1,
+            columns = grep('bed', names(data)),
             digits = 0
           )
         ),

--- a/R/04a_mod_in_app_rating.R
+++ b/R/04a_mod_in_app_rating.R
@@ -36,7 +36,7 @@ mod_in_app_rating_server <- function(id, user_coc, funding_action, nav_control) 
     ## restore last selected project from user_settings DB tbl
     ## also update choices
     observe({
-      req(!is.null(user_coc$coc_version_id) & nav_control() == 'rating')
+      req(!is.null(user_coc$coc_version_id) & nav_control() == 'rating', user_coc$projects_updated)
       
       user_prev_project_selected <- get_user_setting(get_db_pool(), glue::glue('rating_{id}_project_selected'), user_coc$coc_version_id, user_coc$username)
       
@@ -65,7 +65,7 @@ mod_in_app_rating_server <- function(id, user_coc, funding_action, nav_control) 
     
     # Get all projects for the CoC and the current funding action
     all_projects <- reactive({
-      req(user_coc$coc_version_id)
+      req(user_coc$coc_version_id, user_coc$projects_updated)
       funding_action_ids <- get_lookup_refid(
         if(funding_action == "Renew") c("Renew","Expand") else "New",
         "funding_action"

--- a/R/04b_mod_alternative_rating.R
+++ b/R/04b_mod_alternative_rating.R
@@ -54,7 +54,7 @@ mod_alternative_rating_server <- function(id, user_coc) {
     
     output$alternative_rating_table <- renderDT({
       req(user_coc$coc_version_id)
-      data <- ratable_projects() |> fselect(-version_id)
+      data <- isolate(ratable_projects() |> fselect(-version_id))
       
       shiny::validate(need(
         nrow(data) > 0, 
@@ -153,6 +153,12 @@ debugger;
         )
       )
     }, server=FALSE)
+    
+    alt_rating_proxy <- dataTableProxy("alternative_rating_table", session=session)
+    alt_rating_proxy$id <- "alternative_rating_table"
+    observeEvent(ratable_projects(), {
+      replaceData(alt_rating_proxy, ratable_projects() |> fselect(-version_id), resetPaging=FALSE, rownames = FALSE)
+    })
     
     alt_rating_update <- function() {
       updated_project_evaluations = get_updated_project_evaluations(user_coc$username, ratable_projects())

--- a/R/app_db_funcs/db_04a3_mod_rating_scores_entry.R
+++ b/R/app_db_funcs/db_04a3_mod_rating_scores_entry.R
@@ -29,7 +29,10 @@ get_rating_factors_and_scores <- function(coc_version_id, selected_project) {
     params = list(
       coc_version_id,
       selected_project$project_id,
-      selected_project$funding_action,
+      if(selected_project$funding_action %in% get_lookup_refid(c("Renew","Expand"), "funding_action"))
+        get_lookup_refid("Renew", "funding_action")
+      else
+        get_lookup_refid("New", "funding_action"),
       selected_project$project_type,
       target_population
     )

--- a/database/populate_db.R
+++ b/database/populate_db.R
@@ -2,6 +2,17 @@ populate_db <- function(
     add_demo_data = basename(getwd()) != "ORR", 
     USE_SQLITE = Sys.getenv("RSTUDIO") == "1"
 ) {
+  ans <- readline(
+    prompt = "If you proceed, you will erase all database data. Proceed? (Y/N): "
+  )
+  
+  if (toupper(trimws(ans)) != "Y") {
+    message("Cancelled.")
+    return(invisible(NULL))
+  }
+  
+  message("Proceeding...")
+  
 library(here)
 library(DBI)
 library(data.table)

--- a/server.R
+++ b/server.R
@@ -1,5 +1,5 @@
 function(input, output, session) {
-  logger::log_shiny_input_changes(input)
+  logger::log_shiny_input_changes(input, excluded_inputs = c("inventory-projects_table_state"))
   
   user_coc <- reactiveValues(
     coc = NULL,


### PR DESCRIPTION
- fix formatting of bed columns by removing the "-1" in targeting the columns. Otherwise, we were losing geo code because of this formatting being misapplied.
- allow Expand projects to be rated
- fix auto-scroll
- suppress some verbose logging
- ensure newly added projects show up in select project dropdowns after adding