### PR TITLE
feat/slide-in-instructions

### DIFF
--- a/R/00_mod_account.R
+++ b/R/00_mod_account.R
@@ -47,7 +47,7 @@ mod_account_ui <- function(id){
   )
 }
 
-mod_account_server <- function(id, nav_control, user_coc, parent_session) {
+mod_account_server <- function(id, nav_control, user_coc, parent_session, help_id) {
   moduleServer(id, function(input, output, session) {
     
     output$username <- renderText({

--- a/R/01_mod_dashboard.R
+++ b/R/01_mod_dashboard.R
@@ -10,7 +10,7 @@ mod_dashboard_ui <- function(id) {
   )
 }
 
-mod_dashboard_server <- function(id, nav_control, user_coc, parent_session) {
+mod_dashboard_server <- function(id, nav_control, user_coc, parent_session, help_id) {
   moduleServer(id, function(input, output, session) {
     mod_coc_selection_server("coc_selection", nav_control, user_coc, parent_session)
     mod_requests_server("requests", user_coc)

--- a/R/02_mod_inventory.R
+++ b/R/02_mod_inventory.R
@@ -47,7 +47,7 @@ mod_inventory_ui <- function(id) {
   )
 }
 
-mod_inventory_server <- function(id, nav_control, user_coc, parent_session) {
+mod_inventory_server <- function(id, nav_control, user_coc, parent_session, help_id) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     

--- a/R/03_mod_funding_priorities.R
+++ b/R/03_mod_funding_priorities.R
@@ -106,7 +106,7 @@ mod_funding_priorities_ui <- function(id) {
   )
 }
 
-mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_session) {
+mod_funding_priorities_server <- function(id, nav_control, user_coc, parent_session, help_id) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     refresh_trigger <- reactiveValues(

--- a/R/04_mod_rating.R
+++ b/R/04_mod_rating.R
@@ -107,7 +107,7 @@ mod_rating_ui <- function(id) {
   # )
 }
 
-mod_rating_server <- function(id, nav_control, user_coc, parent_session) {
+mod_rating_server <- function(id, nav_control, user_coc, parent_session, help_id) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
@@ -154,6 +154,8 @@ mod_rating_server <- function(id, nav_control, user_coc, parent_session) {
       user_coc$settings$rating_method <- 'in_app'
       shinyjs::addClass(id = "select_in_app", class = "card-selected")
       shinyjs::removeClass(id = "select_alternative", class = "card-selected")
+      
+      help_id(ns("customize_criteria-coc_thresholds")) # Default to the first sub-tab of in-app
     })
     
     observeEvent(input$select_alternative, {
@@ -161,12 +163,21 @@ mod_rating_server <- function(id, nav_control, user_coc, parent_session) {
       user_coc$settings$rating_method <- 'alternative'
       shinyjs::addClass(id = "select_alternative", class = "card-selected")
       shinyjs::removeClass(id = "select_in_app", class = "card-selected")
+      
+      help_id(ns("alternative"))
     })
+    
     
     ## Update rating_tab user setting
     observeEvent(input$rating_tabs, {
       req(!is.null(user_coc$coc_version_id) & nav_control() == 'rating')
       user_coc$settings$rating_tab <- gsub('rating-', '', input$rating_tabs)
+      
+      # Helper slide-in text
+      if(input$rating_tabs == ns("customize_criteria"))
+        help_id(ns("customize_criteria-coc_thresholds"))
+      else
+        help_id(paste0(input$rating_tabs, "-thresholds_entry"))
     }, ignoreInit = TRUE)
     
     # If they uncheck all factors, don't show rating entry ratbs
@@ -182,9 +193,9 @@ mod_rating_server <- function(id, nav_control, user_coc, parent_session) {
       }
     }, ignoreInit = TRUE)
     
-    mod_customize_criteria_server("customize_criteria", user_coc, nav_control, parent_session)
-    mod_in_app_rating_server("renew", user_coc, "Renew", nav_control)
-    mod_in_app_rating_server("new", user_coc, "New", nav_control)
+    mod_customize_criteria_server("customize_criteria", user_coc, nav_control, parent_session, help_id)
+    mod_in_app_rating_server("renew", user_coc, "Renew", nav_control, help_id)
+    mod_in_app_rating_server("new", user_coc, "New", nav_control, help_id)
     mod_rating_summary_server("rating_summary")
     mod_alternative_rating_server("alternative", user_coc)
   })

--- a/R/04a1_mod_customize_criteria.R
+++ b/R/04a1_mod_customize_criteria.R
@@ -32,19 +32,26 @@ mod_customize_criteria_ui <- function(id) {
 #' @param id The module's unique ID.
 #' @param user_coc contains coc_version_id to capture user-selected version of the ORR
 #' @noRd
-mod_customize_criteria_server <- function(id, user_coc, nav_control, parent_session) {
+mod_customize_criteria_server <- function(id, user_coc, nav_control, parent_session, help_id) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
     observeEvent(input$rating_criteria_subtabs, {
       req(!is.null(user_coc$coc_version_id) & nav_control() == 'rating')
-      user_coc$settings$rating_subtab <- gsub('rating-customize_criteria-', '', input$rating_criteria_subtabs)
+      user_coc$settings$rating_subtab <- gsub(ns(''), '', input$rating_criteria_subtabs)
+      
+      if(input$rating_criteria_subtabs == ns("rating_factors"))
+        help_id(ns("renewal_rating_factors"))
+      else
+        help_id(input$rating_criteria_subtabs)
+      
     }, ignoreInit = TRUE)
     
     observeEvent(input$rating_factors_subtabs, {
       req(!is.null(user_coc$coc_version_id) & nav_control() == 'rating')
-      user_coc$settings$rating_subsubtab <- gsub('rating-customize_criteria-', '', input$rating_factors_subtabs)
+      user_coc$settings$rating_subsubtab <- gsub(ns(''), '', input$rating_factors_subtabs)
       
+      help_id(input$rating_factors_subtabs)
     }, ignoreInit = TRUE)
     
     # Call sub-modules for each tab

--- a/R/04a_mod_in_app_rating.R
+++ b/R/04a_mod_in_app_rating.R
@@ -29,7 +29,7 @@ mod_in_app_rating_ui <- function(id, funding_action) {
   )
 }
 
-mod_in_app_rating_server <- function(id, user_coc, funding_action, nav_control) {
+mod_in_app_rating_server <- function(id, user_coc, funding_action, nav_control, help_id) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
@@ -55,6 +55,8 @@ mod_in_app_rating_server <- function(id, user_coc, funding_action, nav_control) 
       
       user_coc$settings$rating_subtab <- gsub(glue::glue('rating-{id}-'), '', input$main_contents)
       toggle_sidebar(id = "project_selection_sidebar", open = input$main_contents != ns("rating_factors"))
+      
+      help_id(input$main_contents)
     }, ignoreInit = TRUE)
     
     # Store selected project in user setting

--- a/R/global_data_prep.R
+++ b/R/global_data_prep.R
@@ -53,3 +53,23 @@ RATABLE_PROJECT_TYPES <- list(
 
 HUD_THRESHOLD_REQUIREMENTS <- get_db_tbl("thresholds") |> 
   fsubset(type == "HUD")
+
+
+POP_GRP_TOGGLES <- expand.grid(
+  pop = get_labelled_lookups("target_population", lookup_col = "value_long"),
+  grp = get_labelled_lookups("population_group", lookup_col = "value_long")
+) |>
+  qDT() |>
+  fmutate(
+    pop_txt = gsub("Domestic Violence", "DV", names(pop)),
+    grp_txt = names(grp)
+  ) |>
+  fsubset(!pop_txt %in% c("Not Applicable", "Human Immunodeficiency Virus")) |>
+  setorder(-grp, pop) |>
+  fmutate(
+    full_text = fcase(
+      pop_txt == "Youth" & grp_txt == "Families", "Parenting Youth",
+      pop_txt == "Youth" & grp_txt == "Individuals", "Single Youth",
+      default = paste(pop_txt, grp_txt)
+    )
+  )

--- a/R/mod_slide_in_instructions.R
+++ b/R/mod_slide_in_instructions.R
@@ -1,0 +1,91 @@
+mod_slide_in_instructions_ui <- function(id) {
+  ns <- NS(id)
+  
+  # Instructions Sidebar
+  div(
+    id = ns("help_sidebar"),
+    
+    # The floating button attached to the outside
+    actionLink(
+      ns("toggle_help"), 
+      label = icon("question-circle")
+    ),
+    
+    # Inner container that handles the scrolling padding
+    div(
+      id = ns("help_sidebar_content"),
+      uiOutput(ns("dynamic_help"))
+    )
+  )
+}
+  
+mod_slide_in_instructions_server <- function(id, user_coc, nav_control) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+    
+    help_id <- reactiveVal("dashboard") # Default
+    
+    
+    help_texts <- list(
+      "dashboard"                                        = tagList(p("A paragraph"), p("Another paragraph")),
+      "inventory"                                        = HTML("<p>Some text</p><ul>Followed by a bullet list<li>item 1</li><li>Item 2</li></ul>"),
+      "funding_priorities"                               = "Funding priority instructions",
+      "rating"                                           = "Select a method to begin.",
+      "rating-alternative"                               = "Upload your external scores...",
+      "rating-customize_criteria-coc_thresholds"         = tagList(h5("Customize CoC Thresholds"), p("Customize CoC threshold criteria")),
+      "rating-customize_criteria-renewal_rating_factors" = tagList(h5("Customize Renewal/Expansion Project Rating Factors"), p("Customize renewal/expansion project rating factors")),
+      "rating-customize_criteria-new_rating_factors"     = tagList(h5("Customize New Project Rating Factors"), p("Customize new project rating factors")),
+      "rating-renew-thresholds_entry"                    = tagList(h5("Renewal/Expansion Project Thresholds"), p("Check threshold eligibility for renewals.")),
+      "rating-renew-rating_scores_entry"                 = tagList(h5("Renewal/Expansion Project Scoring"), p("Enter raw scores for renewal projects.")),
+      "rating-new-thresholds_entry"                      = tagList(h5("New Project Thresholds"), p("Check threshold eligibility for new projects.")),
+      "rating-new-rating_scores_entry"                   = tagList(h5("New Project Scoring"), p("Enter raw scores for new projects.")),
+      "ranking"                                          = "Ranking instructions"
+    )
+    
+    help_wrapper <- function(tab, instructions) {
+      tagList(
+        h4(
+          stringr::str_to_title(paste0(tab, " Instructions")),
+          div(
+            style = "position: absolute; top: 10px; right: 20px;",
+            actionButton("close_help", "X", class = "btn-danger btn-sm")
+          )
+        ),
+        hr(),
+        instructions
+      )
+    }
+    
+    observeEvent(user_coc$auth, {
+      req(user_coc$auth)
+      shinyjs::show("help_sidebar")
+    })
+    
+    observeEvent(input$toggle_help, {
+      shinyjs::toggleClass(id = "help_sidebar", class = "open")
+    })
+    
+    # 2. Close via X button inside the sidebar
+    observeEvent(input$close_help, {
+      shinyjs::removeClass(id = "help_sidebar", class = "open")
+    })
+    
+    output$dynamic_help <- renderUI({
+      req(nav_control())
+      help_wrapper(nav_control(), help_texts[[help_id()]])
+    })
+    
+    
+    # Force collapse sidebar when tab changes ---
+    # This ensures that even if they had help open on Tab A, 
+    # it's gone when they click Tab B.
+    observeEvent(nav_control(), {
+      help_id(nav_control())
+      shinyjs::removeClass(id = "help_sidebar", class = "open")
+    }, ignoreInit = TRUE) 
+    
+    return(help_id)
+  })
+}
+    
+    

--- a/server.R
+++ b/server.R
@@ -32,7 +32,7 @@ function(input, output, session) {
       nav_insert("nav", get(glue::glue("mod_{t}_ui"))(t), select = t == "dashboard")
       
       # Server
-      get(glue::glue("mod_{t}_server"))(t, nav_control, user_coc, session)
+      get(glue::glue("mod_{t}_server"))(t, nav_control, user_coc, session, help_id = help_id)
     })
   })
   
@@ -103,6 +103,9 @@ function(input, output, session) {
     nav_select("nav", selected = nav_control())
   })
 
+  # --- Slide-In Sidebar ----
+  help_id <- mod_slide_in_instructions_server("instructions", user_coc, nav_control)
+  
   shiny::onStop( function(){
     cat("Running onStop")
     

--- a/ui.R
+++ b/ui.R
@@ -142,7 +142,8 @@ page_navbar(
       ),
       overlayColour = '#F5F5F5',
       refresh = ""
-    )
+    ),
+    mod_slide_in_instructions_ui("instructions")
   ),
 
   nav_panel(

--- a/www/custom.css
+++ b/www/custom.css
@@ -159,3 +159,59 @@ table.dataTable .selectize-dropdown-content {
   border-top: 1px solid var(--bs-border-color, #dee2e6);
   box-shadow: 0px -4px 10px rgba(0,0,0,0.05);", # Shadow so it looks like it's floating
 }
+
+
+/* HELP SIDEBAR*/
+/* The Help Sidebar sliding panel */
+#instructions-help_sidebar {
+  display: none; /*Initially hidden until user logs in*/
+  position: fixed;
+  top: 0;
+  right: -400px; /* Hidden completely off-screen */
+  width: 400px;
+  max-width: 100vw;
+  height: 100vh;
+  background-color: #ffffff;
+  box-shadow: -2px 0 8px rgba(0,0,0,0.2);
+  z-index: 99998; 
+  transition: right 0.4s ease-in-out; 
+  
+  /* CRITICAL: Must be visible so the attached button shows outside the box */
+  overflow: visible; 
+}
+
+#instructions-help_sidebar.open {
+  right: 0; 
+}
+
+/* The button that sticks out the left side of the panel */
+#instructions-toggle_help {
+  position: absolute;
+  top: 80px; /* Distance from the top of the screen */
+  left: -50px; /* Pulls it entirely out of the left side of the panel */
+  width: 50px;
+  height: 50px;
+  background-color: #0d6efd; /* Bootstrap Primary Blue - adjust to your theme */
+  color: white;
+  border-radius: 8px 0 0 8px; /* Round only the left corners */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  box-shadow: -2px 0px 5px rgba(0,0,0,0.2);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+#instructions-toggle_help:hover, #toggle_help:focus {
+  color: white;
+  background-color: #0b5ed7;
+}
+
+/* Scrollable container inside for the actual content */
+#instructions-help_sidebar_content {
+  height: 100vh;
+  padding: 20px;
+  overflow-y: auto; /* Handles scrolling for the text */
+}
+  


### PR DESCRIPTION
- make the slide-in instructions sidebar a module to keep things tidy
- need to return and pass around `help_id` which stores where the user is and thus determines which instructions to show.

We will of course need to update the instructions themselves