### PR TITLE
Automatically log user back in if possible

### DIFF
--- a/R/00_mod_account.R
+++ b/R/00_mod_account.R
@@ -6,21 +6,6 @@ mod_account_ui <- function(id){
     title = "Account",
     icon = icon('user'),
     value = id,
-    # nav_panel( 
-    #   title = 'Request Access',
-    #   mod_requests_ui('requests')
-    # ),
-    # nav_panel(
-    #   title = 'View Versions'
-    # ),
-    # nav_item(
-    #   value = "sign_in",
-    #   tags$a("Log in", id = "submit_sign_in", href = aws_auth_redirect)
-    # ),
-    # nav_item(
-    #   value = "sign_up",
-    #   tags$a("Create Account", id = "submit_sign_up", href = aws_auth_signup)
-    # ),
     nav_item(
       value = "user_details",
       textOutput(ns('username'))
@@ -28,7 +13,12 @@ mod_account_ui <- function(id){
     ## link to log out of application
     nav_item(
       value = "sign_out",
-      tags$a("Log Out", id = "submit_sign_out", href = aws_auth_logout)
+      tags$a(
+        "Log Out", 
+        id = "submit_sign_out", 
+        href = aws_auth_logout,
+        onclick = "clear_cookie()"
+      )
     )
   )
 }

--- a/server.R
+++ b/server.R
@@ -61,10 +61,22 @@ function(input, output, session) {
       # if an error occurred during login
       if (is.null(current_user)){
         message('user is NULL')
+        
+        # 2. CLEAR COOKIE: Remove the cookie so we don't get stuck in an auto-redirect loop
+        shinyjs::runjs("clear_cookie();")
+        
         #hideElement("login_welcome_text")
         user_coc$auth <- FALSE
       } else {
         message('user found!')
+        
+        # 3. SET COOKIE: Set a browser cookie to expire in 30 minutes
+        shinyjs::runjs("
+          let expires = new Date();
+          expires.setTime(expires.getTime() + (60 * 60 * 1000)); // 60 minutes, to match Cognito
+          document.cookie = 'cognito_session=active;expires=' + expires.toUTCString() + ';path=/';
+        ")
+        
         # check if user is in allowed user list
         if (!(str_to_lower(current_user$email) %in% str_to_lower(get_db_tbl('users')$username))){
           message("new user added to allowed list")
@@ -88,6 +100,13 @@ function(input, output, session) {
         user_coc$auth <- TRUE
         user_coc$username <- current_user$email
         user_coc$given_name <- current_user$given_name
+        
+
+        # 4. CLEAN THE URL: Strip the single-use ?code=... from the URL. 
+        # If the user refreshes, they will hit the clean URL, our cookie logic 
+        # will catch them, and seamlessly fetch a new code from Cognito.
+        updateQueryString(session$clientData$url_pathname, mode = "replace", session = session)
+        
         nav_control("dashboard")
         session$sendCustomMessage("auth_state", TRUE)
       }

--- a/ui.R
+++ b/ui.R
@@ -24,6 +24,7 @@ page_navbar(
         aws_auth_logout
       ))),
       
+      tags$script(src = "js/auth_cookie.js"),
       tags$script(src = "js/disconnect.js"),
       tags$script(src = "js/datatable_helpers.js") # Loaded once for the whole app
     ), # end tags$head

--- a/www/js/auth_cookie.js
+++ b/www/js/auth_cookie.js
@@ -1,0 +1,27 @@
+/*PURPOSE: Script to redirect user if auth cookie is found*/
+function clear_cookie() {
+  document.cookie = 'cognito_session=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/';
+}
+
+/*Check for `cognito_session` cookie*/
+const hasSession = document.cookie.includes('cognito_session=active');
+
+/*Once authenticated, Cognito generates a secure, single-use, 
+highly encrypted Authorization Code on AWS's servers
+ORR makes a secure, behind-the-scenes HTTP request back to Cognito to exchange 
+it for the actual user details and Access Tokens*/
+const hasCode = window.location.search.includes('code=');
+
+/*If something goes wrong on Cognito's end (for example, the user clicks "Cancel", 
+or they are denied access), Cognito will redirect them back with an error in the 
+URL instead of a code: ?error=access_denied.
+Because our UI JavaScript only checks for !hasCode, it will instantly redirect 
+the user back to Cognito, which will instantly return the error again, creating 
+an infinite flashing loop that crashes the browser tab.*/
+const hasError = window.location.search.includes('error=');
+
+
+// If they have an active session cookie, but NO code in the URL, redirect instantly!
+if (hasSession && !hasCode && !hasError) {
+  window.location.href = window.AUTH_CONFIG.redirectUrl;
+}


### PR DESCRIPTION
We do this by storing a simple cookie called `cognito_session` on the user's browser. When they arrive at the app (via refresh or otherwise) we check for the cookie. If it's there, we automatically redirect them through the Cognito auth process (instead of them clicking "Login"). If it's not there, they have to click "Login", and, when cognito redirects back, the cookie is set.

If we see the "code=" query paramter, it means they actually signed in through Cognito. After logging in, we remove it to make sure our cookie catches them first.

clear cookie on logout