### PR TITLE
update handling of "negative factors":

### DIFF
--- a/R/04a1b_mod_customize_rating_factors.R
+++ b/R/04a1b_mod_customize_rating_factors.R
@@ -172,7 +172,7 @@ mod_customize_rating_factors_server <- function(id, user_coc, funding_action, na
           div(style = "flex: 1;", "Target Population"),
           div(style = "flex: 3;", "Rating Factor"),
           div(style = "flex: 1;", "Goal"),
-          div(style = "flex: 0 0 80px;", "Max Points")
+          div(style = "flex: 0 0 80px;", "Total Points")
         ),
         hr(),
         factor_rows
@@ -332,12 +332,16 @@ mod_customize_rating_factors_server <- function(id, user_coc, funding_action, na
           
           shinyWidgets::autonumericInput(
             inputId = ns("custom_points"),
-            label = "Max Point Value*", 
+            label = HTML("Total Point Value*<br><p style='font-size: 0.8em'; margin-bottom: 0px;>(can be negative)</span>"), 
             value = NA,
             align = "center",
             decimalPlaces = 1,
             minimumValue = -999.9,
             maximumValue = 999.9
+          ),
+          
+          hidden(
+            p(id = ns("custom_factor_helper"), "A negative value represents that maximum number of points you can deduct from a project for this factor")
           ),
           
           footer = tagList(
@@ -348,6 +352,9 @@ mod_customize_rating_factors_server <- function(id, user_coc, funding_action, na
       )
     }, ignoreInit = TRUE)
     
+    observeEvent(input$custom_points, {
+      shinyjs::toggle(id = "custom_factor_helper", condition = input$custom_points < 0)
+    })
     observeEvent(input$cancel_custom_factor, {
       iv_custom$disable()
       removeModal()

--- a/R/04a1b_mod_customize_rating_factors.R
+++ b/R/04a1b_mod_customize_rating_factors.R
@@ -341,7 +341,7 @@ mod_customize_rating_factors_server <- function(id, user_coc, funding_action, na
           ),
           
           hidden(
-            p(id = ns("custom_factor_helper"), "A negative value represents that maximum number of points you can deduct from a project for this factor")
+            p(id = ns("custom_factor_helper"), "A negative value represents the maximum number of points you can deduct from a project for this factor")
           ),
           
           footer = tagList(

--- a/R/04a3_mod_rating_scores_entry.R
+++ b/R/04a3_mod_rating_scores_entry.R
@@ -199,11 +199,18 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, fundi
                     value = rating_score,
                     align = "center",
                     decimalPlaces = 0,
-                    minimumValue = -999,
-                    maximumValue = max_points
+                    minimumValue = ifelse(max_points < 0, max_points, 0),
+                    maximumValue = ifelse(max_points < 0, 0, max_points)
                   )) |>
                     tagAppendAttributes(class = 'score-input', `data-group` = group_id),
-                p(paste("out of", max_points), style="padding-top: 5px;")
+                p(
+                  ifelse(
+                    max_points > 0, 
+                    paste("out of", max_points), 
+                    paste0("(deduct up to ", max_points, ")")
+                  ),
+                  style="padding-top: 5px;"
+                )
               )
             }
           )


### PR DESCRIPTION
- these should be seen simply as factors for which a user can deduct points from a project
- so we change the "Max Point" language to "Total Point" to be more broadly applicable
- for our factors, max points can be 0 to 999.9.
- But for custom factors, they can be between -999.9 and 999.9. If negative, they are "deduction factors" and we explain this to the user as such
- on the score entry page, min and max values are between the saved "max" and 0 if max is negative, and between 0 and max otherwise.