### PR TITLE
Hotfix/misc

### DIFF
--- a/R/02a_mod_inventory_add_project.R
+++ b/R/02a_mod_inventory_add_project.R
@@ -9,7 +9,7 @@ LOOKUP_CHOICES <- list(
   dv_reallocation_project_types = c("RRH", "TH+RRH", "SSO - CE"),
   # funding_source = c("CoC","YHDP","DV"), # According to guidance from HUD on 4/20/26, no separate YHDP bucket
   funding_source = c("CoC","DV"),
-  target_populations = LOOKUPS[reference_type == 'target_population']$value #c("DV","HIV","Youth", "General") # AS 8/26: What are the right populations here?
+  target_populations = setdiff(LOOKUPS[reference_type == 'target_population']$value, "General") # all populations
 )
 
 # ===================================================================

--- a/R/04a3_mod_rating_scores_entry.R
+++ b/R/04a3_mod_rating_scores_entry.R
@@ -91,11 +91,11 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, fundi
     
     
     observeEvent(c(selected_project(), refresh_trigger(), user_coc[[paste0("customized_rating_factors_updated_", funding_action)]]), {
+      shinyjs::disable("rating_complete")
+      
       req(user_coc$coc_version_id)
       
       project_is_selected <- isTruthy(fnrow(selected_project()) > 0)
-      shinyjs::toggleState("rating_complete", condition = project_is_selected)
-      
       req(project_is_selected)
       
       # individual threshold entries
@@ -105,6 +105,8 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, fundi
           selected_project()
         ) 
       )
+      
+      shinyjs::toggleState("rating_complete", condition = project_is_selected && fnrow(factors_and_scores_for_project()) > 0)
       
       # project-level evaluations
       project_evaluation(
@@ -136,7 +138,7 @@ mod_rating_scores_entry_server <- function(id, user_coc, selected_project, fundi
       }
       
       shiny::validate(
-        need(hasProjects(), paste0("You do not have any ", funding_action, " projects to threshold. Add them on the Review tab.")),
+        need(hasProjects(), paste0("You do not have any ", funding_action, " projects to rate. Add them on the Review tab.")),
         need(project_is_selected, "Select a project in the left-hand sidebar to begin rating")
       )
       shiny::validate(

--- a/R/04a_mod_in_app_rating.R
+++ b/R/04a_mod_in_app_rating.R
@@ -77,8 +77,9 @@ mod_in_app_rating_server <- function(id, user_coc, funding_action, nav_control, 
     
     ## restore last selected project from user_settings DB tbl
     ## also update choices
-    observe({
-      req(!is.null(user_coc$coc_version_id) & nav_control() == 'rating', user_coc$projects_updated)
+    observeEvent(nav_control(), {
+      req(nav_control() == 'rating')
+      req(all_projects())
       
       user_prev_project_selected <- get_user_setting(user_coc, 'project_selected') |> as.integer()
       
@@ -151,8 +152,11 @@ mod_in_app_rating_server <- function(id, user_coc, funding_action, nav_control, 
     selected_project <- reactive({
       req(user_coc$coc_version_id)
       
-      all_projects() |> 
-        fsubset(project_id == input$project_select)
+      if(input$project_select != "")
+        all_projects() |> 
+          fsubset(project_id == input$project_select)
+      else
+        data.table()
     })
     
     # Show project info about the selected project

--- a/R/app_db_funcs/db_04a3_mod_rating_scores_entry.R
+++ b/R/app_db_funcs/db_04a3_mod_rating_scores_entry.R
@@ -1,10 +1,9 @@
 # Get the rating factor info to construct UI
 get_rating_factors_and_scores <- function(coc_version_id, selected_project) {
   target_population <- ifelse(
-    is.na(selected_project$target_population) || 
-      get_lookup_label(selected_project$target_population, 'target_population') == 'NA',
-    get_lookup_refid('General', 'target_population'),
-    selected_project$target_population
+    selected_project$target_population == get_lookup_refid('DV', 'target_population'),
+    selected_project$target_population,
+    get_lookup_refid('General', 'target_population')
   )
   
   get_db_query(


### PR DESCRIPTION
- disable rating complete until it needs to be enabled, which shouldbe based not just on the project being selected but there also being any factors selected
- fixing typo in shiny validation (referenced "threshold" rather than "rate".
- only pull selected project from user settings when they navigate to the rating tab.
- handle no selected project (otherwise, it was getting deselected and causing db errors.