### PR TITLE
Remove ES projects from HIC

### DIFF
--- a/database/populate_db.R
+++ b/database/populate_db.R
@@ -119,7 +119,8 @@ populate_db <- function(
       mckinneyventococ = FALSE,
       created_by = SERVICE_ACCOUNT, 
       updated_by = SERVICE_ACCOUNT
-    )
+    ) %>% 
+    fsubset(project_type != 'ES')
   
   # Fetch lookup tables from database
   lookups <- pool::poolWithTransaction(p, function(pcon) {


### PR DESCRIPTION
Since they cannot be rated or ranked, they are not needed in the app / inventory table. This is consistent with the Excel tool. 

It should also help with efficiency and processing time for larger CoCs, since they have a good share of projects that are ES.