### PR TITLE
remove Vet beds when Youth is the target pop

### DIFF
--- a/R/02a_mod_inventory_add_project.R
+++ b/R/02a_mod_inventory_add_project.R
@@ -134,11 +134,11 @@ mod_inventory_add_project_server <- function(
       else if(is.null(input$target_population) || input$target_population == "") ""
       else input$target_population
       
-      if(tp == "Youth")
-        req_validator$disable()
+      if(tp == "Veteran")
+        vet_beds_required$enable()
       else
-        req_validator$enable()
-      
+        vet_beds_required$disable()
+        
       tp
     })
     
@@ -159,6 +159,7 @@ mod_inventory_add_project_server <- function(
       else { # CoC logic
         groups <- c("total_beds", "vet_beds")
         if (tp == "Youth" || tp == "") groups <- c(groups, "youth_beds")
+        if (tp %in% c("Youth", "HIV")) groups <- setdiff(groups, "vet_beds")
         if (pt == "PSH" || is.null(pt) || pt == "") groups <- c(groups, "ch_beds")
       }
       return(groups)
@@ -371,13 +372,13 @@ mod_inventory_add_project_server <- function(
         
         # Vet beds will be conditionally required based on Target Pop (i.e. not required if Youth)
         if(group_name == "vet_beds") {
-          req_validator <- shinyvalidate::InputValidator$new()
-          v$add_validator(req_validator)
+          vet_beds_required <- shinyvalidate::InputValidator$new()
+          v$add_validator(vet_beds_required)
         }
         
         # Add rules for the fields within this group
         for (field in bed_groups_to_validate[[current_group]]) {
-          if(group_name == "vet_beds") req_validator$add_rule(field, sv_required())
+          if(group_name == "vet_beds") vet_beds_required$add_rule(field, sv_required())
           else v$add_rule(field, sv_required())
           v$add_rule(field, sv_integer("Must be a whole number"))
           v$add_rule(field, sv_gte(0, "Cannot be negative"))

--- a/R/02a_mod_inventory_add_project.R
+++ b/R/02a_mod_inventory_add_project.R
@@ -134,11 +134,6 @@ mod_inventory_add_project_server <- function(
       else if(is.null(input$target_population) || input$target_population == "") ""
       else input$target_population
       
-      if(tp == "Veteran")
-        vet_beds_required$enable()
-      else
-        vet_beds_required$disable()
-        
       tp
     })
     
@@ -162,6 +157,12 @@ mod_inventory_add_project_server <- function(
         if (tp %in% c("Youth", "HIV")) groups <- setdiff(groups, "vet_beds")
         if (pt == "PSH" || is.null(pt) || pt == "") groups <- c(groups, "ch_beds")
       }
+      
+      if(tp == "Veteran")
+        vet_beds_required$enable()
+      else
+        vet_beds_required$disable()
+      
       return(groups)
     })
     

--- a/R/02a_mod_inventory_add_project.R
+++ b/R/02a_mod_inventory_add_project.R
@@ -152,6 +152,7 @@ mod_inventory_add_project_server <- function(
       else { # CoC logic
         groups <- c("total_beds", "vet_beds")
         if (tp == "Youth" || tp == "") groups <- c(groups, "youth_beds")
+        if (tp == "Youth") groups <- setdiff(groups, "vet_beds")
         if (pt == "PSH" || is.null(pt) || pt == "") groups <- c(groups, "ch_beds")
       }
       return(groups)

--- a/R/02a_mod_inventory_add_project.R
+++ b/R/02a_mod_inventory_add_project.R
@@ -358,26 +358,23 @@ mod_inventory_add_project_server <- function(
         }
       }
     }
+    
+    # Dedicated sub-validator for veteran beds requirement
+    vet_beds_required <- shinyvalidate::InputValidator$new()
+    vet_beds_required$condition(~ current_target_pop() == "Veteran")
+    
     # Loop to create and add all bed validation rules ONCE
     for (group_name in names(bed_groups_to_validate)) {
-      # Use local() to capture the current value of 'group_name' for the condition formula
       local({
         current_group <- group_name
         
-        # Create a new validator for this group
         v <- shinyvalidate::InputValidator$new()
-        
-        # Set the condition for the ENTIRE validator group.
-        # This is much more efficient than setting it inside an observe().
         v$condition(~ current_group %in% visible_bed_groups())
         
-        # Vet beds will be conditionally required based on Target Pop (i.e. not required if Youth)
         if(group_name == "vet_beds") {
-          vet_beds_required <- shinyvalidate::InputValidator$new()
           v$add_validator(vet_beds_required)
         }
         
-        # Add rules for the fields within this group
         for (field in bed_groups_to_validate[[current_group]]) {
           if(group_name == "vet_beds") vet_beds_required$add_rule(field, sv_required())
           else v$add_rule(field, sv_required())
@@ -385,13 +382,11 @@ mod_inventory_add_project_server <- function(
           v$add_rule(field, sv_gte(0, "Cannot be negative"))
         }
         
-        # Subset validation
         if (current_group != "total_beds") {
           v$add_rule(paste0(current_group, "_fam"), sv_lte_reactive(~input$total_beds_fam))
           v$add_rule(paste0(current_group, "_ind"), sv_lte_reactive(~input$total_beds_ind))
         }
         
-        # Add this group's validator to the main validator
         iv$add_validator(v)
       })
     }

--- a/R/02a_mod_inventory_add_project.R
+++ b/R/02a_mod_inventory_add_project.R
@@ -130,9 +130,16 @@ mod_inventory_add_project_server <- function(
     # Determine the definitive target population.
     current_target_pop <- reactive({
       # if (current_funding_source() == "YHDP") "Youth" 
-      if (current_funding_source() == "DV") "DV" 
+      tp <- if (current_funding_source() == "DV") "DV" 
       else if(is.null(input$target_population) || input$target_population == "") ""
       else input$target_population
+      
+      if(tp == "Youth")
+        req_validator$disable()
+      else
+        req_validator$enable()
+      
+      tp
     })
     
     # Determine which bed groups should be visible. This is the core of the display logic.
@@ -152,7 +159,6 @@ mod_inventory_add_project_server <- function(
       else { # CoC logic
         groups <- c("total_beds", "vet_beds")
         if (tp == "Youth" || tp == "") groups <- c(groups, "youth_beds")
-        if (tp == "Youth") groups <- setdiff(groups, "vet_beds")
         if (pt == "PSH" || is.null(pt) || pt == "") groups <- c(groups, "ch_beds")
       }
       return(groups)
@@ -363,9 +369,16 @@ mod_inventory_add_project_server <- function(
         # This is much more efficient than setting it inside an observe().
         v$condition(~ current_group %in% visible_bed_groups())
         
+        # Vet beds will be conditionally required based on Target Pop (i.e. not required if Youth)
+        if(group_name == "vet_beds") {
+          req_validator <- shinyvalidate::InputValidator$new()
+          v$add_validator(req_validator)
+        }
+        
         # Add rules for the fields within this group
         for (field in bed_groups_to_validate[[current_group]]) {
-          v$add_rule(field, sv_required())
+          if(group_name == "vet_beds") req_validator$add_rule(field, sv_required())
+          else v$add_rule(field, sv_required())
           v$add_rule(field, sv_integer("Must be a whole number"))
           v$add_rule(field, sv_gte(0, "Cannot be negative"))
         }


### PR DESCRIPTION
As requested by Louise for the Add Project pop-up:
- hide Vet beds if Target Pop is Youth or HIV
- only require them if Target Pop is Veteran